### PR TITLE
Add support for S3

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -24,6 +24,7 @@ func init() {
 	Detectors = []Detector{
 		new(GitHubDetector),
 		new(BitBucketDetector),
+		new(S3Detector),
 		new(FileDetector),
 	}
 }

--- a/detect_s3.go
+++ b/detect_s3.go
@@ -28,7 +28,7 @@ func (d *S3Detector) Detect(src, _ string) (string, bool, error) {
 
 func (d *S3Detector) detectHTTP(src string) (string, bool, error) {
 	parts := strings.Split(src, "/")
-	if len(parts) < 0 {
+	if len(parts) < 2 {
 		return "", false, fmt.Errorf(
 			"URL is not a valid S3 URL")
 	}
@@ -48,7 +48,7 @@ func (d *S3Detector) detectPathStyle(region string, parts []string) (string, boo
 	urlStr := fmt.Sprintf("https://%s.amazonaws.com/%s", region, strings.Join(parts, "/"))
 	url, err := url.Parse(urlStr)
 	if err != nil {
-		return "", true, fmt.Errorf("error parsing GitHub URL: %s", err)
+		return "", false, fmt.Errorf("error parsing S3 URL: %s", err)
 	}
 
 	return "s3::" + url.String(), true, nil
@@ -58,7 +58,7 @@ func (d *S3Detector) detectVhostStyle(region, bucket string, parts []string) (st
 	urlStr := fmt.Sprintf("https://%s.amazonaws.com/%s/%s", region, bucket, strings.Join(parts, "/"))
 	url, err := url.Parse(urlStr)
 	if err != nil {
-		return "", true, fmt.Errorf("error parsing S3 URL: %s", err)
+		return "", false, fmt.Errorf("error parsing S3 URL: %s", err)
 	}
 
 	return "s3::" + url.String(), true, nil

--- a/detect_s3.go
+++ b/detect_s3.go
@@ -63,27 +63,3 @@ func (d *S3Detector) detectVhostStyle(region, bucket string, parts []string) (st
 
 	return "s3::" + url.String(), true, nil
 }
-
-// func (d *S3Detector) detectSSH(src string) (string, bool, error) {
-// 	idx := strings.Index(src, ":")
-// 	qidx := strings.Index(src, "?")
-// 	if qidx == -1 {
-// 		qidx = len(src)
-// 	}
-
-// 	var u url.URL
-// 	u.Scheme = "ssh"
-// 	u.User = url.User("git")
-// 	u.Host = "github.com"
-// 	u.Path = src[idx+1 : qidx]
-// 	if qidx < len(src) {
-// 		q, err := url.ParseQuery(src[qidx+1:])
-// 		if err != nil {
-// 			return "", true, fmt.Errorf("error parsing GitHub SSH URL: %s", err)
-// 		}
-
-// 		u.RawQuery = q.Encode()
-// 	}
-
-// 	return "git::" + u.String(), true, nil
-// }

--- a/detect_s3.go
+++ b/detect_s3.go
@@ -6,10 +6,6 @@ import (
 	"strings"
 )
 
-const (
-	vhostFormat = ""
-)
-
 // S3Detector implements Detector to detect S3 URLs and turn
 // them into URLs that the S3 getter can understand.
 type S3Detector struct{}

--- a/detect_s3_test.go
+++ b/detect_s3_test.go
@@ -59,6 +59,11 @@ func TestS3Detector(t *testing.T) {
 			"s3-eu-west-1.amazonaws.com/bucket/foo/bar.baz",
 			"s3::https://s3-eu-west-1.amazonaws.com/bucket/foo/bar.baz",
 		},
+		// Misc tests
+		{
+			"s3-eu-west-1.amazonaws.com/bucket/foo/bar.baz?version=1234",
+			"s3::https://s3-eu-west-1.amazonaws.com/bucket/foo/bar.baz?version=1234",
+		},
 	}
 
 	pwd := "/pwd"

--- a/detect_s3_test.go
+++ b/detect_s3_test.go
@@ -1,0 +1,79 @@
+package getter
+
+import (
+	"testing"
+)
+
+func TestS3Detector(t *testing.T) {
+	cases := []struct {
+		Input  string
+		Output string
+	}{
+		// Virtual hosted style
+		{
+			"bucket.s3.amazonaws.com/foo",
+			"s3::https://s3.amazonaws.com/bucket/foo",
+		},
+		{
+			"bucket.s3.amazonaws.com/foo/bar",
+			"s3::https://s3.amazonaws.com/bucket/foo/bar",
+		},
+		{
+			"bucket.s3.amazonaws.com/foo/bar.baz",
+			"s3::https://s3.amazonaws.com/bucket/foo/bar.baz",
+		},
+		{
+			"bucket.s3-eu-west-1.amazonaws.com/foo",
+			"s3::https://s3-eu-west-1.amazonaws.com/bucket/foo",
+		},
+		{
+			"bucket.s3-eu-west-1.amazonaws.com/foo/bar",
+			"s3::https://s3-eu-west-1.amazonaws.com/bucket/foo/bar",
+		},
+		{
+			"bucket.s3-eu-west-1.amazonaws.com/foo/bar.baz",
+			"s3::https://s3-eu-west-1.amazonaws.com/bucket/foo/bar.baz",
+		},
+		// Path style
+		{
+			"s3.amazonaws.com/bucket/foo",
+			"s3::https://s3.amazonaws.com/bucket/foo",
+		},
+		{
+			"s3.amazonaws.com/bucket/foo/bar",
+			"s3::https://s3.amazonaws.com/bucket/foo/bar",
+		},
+		{
+			"s3.amazonaws.com/bucket/foo/bar.baz",
+			"s3::https://s3.amazonaws.com/bucket/foo/bar.baz",
+		},
+		{
+			"s3-eu-west-1.amazonaws.com/bucket/foo",
+			"s3::https://s3-eu-west-1.amazonaws.com/bucket/foo",
+		},
+		{
+			"s3-eu-west-1.amazonaws.com/bucket/foo/bar",
+			"s3::https://s3-eu-west-1.amazonaws.com/bucket/foo/bar",
+		},
+		{
+			"s3-eu-west-1.amazonaws.com/bucket/foo/bar.baz",
+			"s3::https://s3-eu-west-1.amazonaws.com/bucket/foo/bar.baz",
+		},
+	}
+
+	pwd := "/pwd"
+	f := new(S3Detector)
+	for i, tc := range cases {
+		output, ok, err := f.Detect(tc.Input, pwd)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+		if !ok {
+			t.Fatal("not ok")
+		}
+
+		if output != tc.Output {
+			t.Fatalf("%d: bad: %#v", i, output)
+		}
+	}
+}

--- a/get.go
+++ b/get.go
@@ -43,7 +43,7 @@ var Getters map[string]Getter
 
 // forcedRegexp is the regular expression that finds forced getters. This
 // syntax is schema::url, example: git::https://foo.com
-var forcedRegexp = regexp.MustCompile(`^([A-Za-z]+)::(.+)$`)
+var forcedRegexp = regexp.MustCompile(`^([A-Za-z0-9]+)::(.+)$`)
 
 func init() {
 	httpGetter := new(HttpGetter)
@@ -52,6 +52,7 @@ func init() {
 		"file":  new(FileGetter),
 		"git":   new(GitGetter),
 		"hg":    new(HgGetter),
+		"s3":    new(S3Getter),
 		"http":  httpGetter,
 		"https": httpGetter,
 	}

--- a/get_s3.go
+++ b/get_s3.go
@@ -1,0 +1,66 @@
+package getter
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+// S3Getter is a Getter implementation that will download a module from
+// a S3 bucket.
+type S3Getter struct{}
+
+func (g *S3Getter) Get(dst string, u *url.URL) error {
+	return fmt.Errorf("Operation is unsupported")
+}
+
+func (g *S3Getter) GetFile(dst string, u *url.URL) error {
+	region, bucket, path, err := g.parseUrl(u)
+	if err != nil {
+		return err
+	}
+
+	client := s3.New(&aws.Config{Region: aws.String(region)})
+	resp, err := client.GetObject(&s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(path),
+	})
+	if err != nil {
+		return err
+	}
+
+	// Create all the parent directories
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return err
+	}
+
+	f, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = io.Copy(f, resp.Body)
+	return err
+}
+
+func (g *S3Getter) parseUrl(u *url.URL) (region, bucket, path string, err error) {
+	hostParts := strings.Split(u.Host, ".")
+
+	if len(hostParts) != 3 {
+		return "", "", "", fmt.Errorf("URL is not a valid S3 URL")
+	}
+	region = strings.TrimPrefix(strings.TrimPrefix(hostParts[0], "s3-"), "s3")
+
+	pathParts := strings.Split(u.Path, "/")
+	bucket = pathParts[1]
+	path = strings.Join(pathParts[2:], "/")
+
+	return
+}

--- a/get_s3.go
+++ b/get_s3.go
@@ -7,9 +7,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
@@ -131,6 +133,15 @@ func (g *S3Getter) getObject(client *s3.S3, dst, bucket, key, version string) er
 
 func (g *S3Getter) getAWSConfig(region string, creds *credentials.Credentials) *aws.Config {
 	conf := &aws.Config{}
+	if creds == nil {
+		creds = credentials.NewChainCredentials(
+			[]credentials.Provider{
+				&credentials.EnvProvider{},
+				&credentials.SharedCredentialsProvider{Filename: "", Profile: ""},
+				&ec2rolecreds.EC2RoleProvider{ExpiryWindow: 5 * time.Minute},
+			})
+	}
+
 	conf.Credentials = creds
 	if region != "" {
 		conf.Region = aws.String(region)

--- a/get_s3.go
+++ b/get_s3.go
@@ -17,7 +17,75 @@ import (
 type S3Getter struct{}
 
 func (g *S3Getter) Get(dst string, u *url.URL) error {
-	return fmt.Errorf("Operation is unsupported")
+	// Parse URL
+	region, bucket, path, err := g.parseUrl(u)
+	if err != nil {
+		return err
+	}
+
+	// Remove destination if it already exists
+	_, err = os.Stat(dst)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	if err == nil {
+		// Remove the destination
+		if err := os.RemoveAll(dst); err != nil {
+			return err
+		}
+	}
+
+	// Create all the parent directories
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return err
+	}
+
+	client := s3.New(&aws.Config{Region: aws.String(region)})
+
+	// List files in path, keep listing until no more objects are found
+	lastMarker := ""
+	hasMore := true
+	for hasMore {
+		req := &s3.ListObjectsInput{
+			Bucket: aws.String(bucket),
+			Prefix: aws.String(path),
+		}
+
+		if lastMarker != "" {
+			req.Marker = aws.String(lastMarker)
+		}
+
+		resp, err := client.ListObjects(req)
+		if err != nil {
+			return err
+		}
+
+		hasMore = aws.BoolValue(resp.IsTruncated)
+
+		for _, object := range resp.Contents {
+			lastMarker = aws.StringValue(object.Key)
+			objPath := aws.StringValue(object.Key)
+
+			// If the key ends with a backslash assume it is a directory and ignore
+			if strings.HasSuffix(objPath, "/") {
+				continue
+			}
+
+			// Get the object destination path
+			objDst, err := filepath.Rel(path, objPath)
+			if err != nil {
+				return err
+			}
+			objDst = filepath.Join(dst, objDst)
+
+			if err := g.getObject(client, objDst, bucket, objPath); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 func (g *S3Getter) GetFile(dst string, u *url.URL) error {
@@ -27,9 +95,14 @@ func (g *S3Getter) GetFile(dst string, u *url.URL) error {
 	}
 
 	client := s3.New(&aws.Config{Region: aws.String(region)})
+
+	return g.getObject(client, dst, bucket, path)
+}
+
+func (g *S3Getter) getObject(client *s3.S3, dst, bucket, key string) error {
 	resp, err := client.GetObject(&s3.GetObjectInput{
 		Bucket: aws.String(bucket),
-		Key:    aws.String(path),
+		Key:    aws.String(key),
 	})
 	if err != nil {
 		return err

--- a/get_s3.go
+++ b/get_s3.go
@@ -148,7 +148,7 @@ func (g *S3Getter) parseUrl(u *url.URL) (region, bucket, path, version string, c
 	region = strings.TrimPrefix(strings.TrimPrefix(hostParts[0], "s3-"), "s3")
 
 	pathParts := strings.Split(u.Path, "/")
-	if len(pathParts) < 3 {
+	if len(pathParts) < 2 {
 		return "", "", "", "", nil, fmt.Errorf("URL is not a valid S3 URL")
 	}
 

--- a/get_s3_test.go
+++ b/get_s3_test.go
@@ -74,3 +74,18 @@ func TestS3Getter_GetFile_params(t *testing.T) {
 		t.Fatalf("expected InvalidAccessKeyId error")
 	}
 }
+
+func TestS3Getter_GetFile_notfound(t *testing.T) {
+	g := new(S3Getter)
+	dst := tempFile(t)
+
+	// Download
+	err := g.GetFile(dst, testURL("https://s3-eu-west-1.amazonaws.com/hailo-s3-test/notfound.txt"))
+	if err == nil {
+		t.Fatalf("expected error, got none")
+	}
+
+	if reqerr, ok := err.(awserr.RequestFailure); !ok || reqerr.StatusCode() != 404 {
+		t.Fatalf("expected InvalidAccessKeyId error")
+	}
+}

--- a/get_s3_test.go
+++ b/get_s3_test.go
@@ -1,0 +1,59 @@
+package getter
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestS3Getter_impl(t *testing.T) {
+	var _ Getter = new(S3Getter)
+}
+
+func TestS3Getter(t *testing.T) {
+	g := new(S3Getter)
+	dst := tempDir(t)
+
+	// With a dir that doesn't exist
+	if err := g.Get(dst, testURL("https://s3-eu-west-1.amazonaws.com/hailo-s3-test")); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Verify the main file exists
+	mainPath := filepath.Join(dst, "main.tf")
+	if _, err := os.Stat(mainPath); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestS3Getter_Subdir(t *testing.T) {
+	g := new(S3Getter)
+	dst := tempDir(t)
+
+	// With a dir that doesn't exist
+	if err := g.Get(dst, testURL("https://s3-eu-west-1.amazonaws.com/hailo-s3-test/subdir")); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Verify the main file exists
+	subPath := filepath.Join(dst, "sub.tf")
+	if _, err := os.Stat(subPath); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestS3Getter_GetFile(t *testing.T) {
+	g := new(S3Getter)
+	dst := tempFile(t)
+
+	// Download
+	if err := g.GetFile(dst, testURL("https://s3-eu-west-1.amazonaws.com/hailo-s3-test/foo.txt")); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Verify the main file exists
+	if _, err := os.Stat(dst); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	assertContents(t, dst, "Hello\n")
+}

--- a/module_test.go
+++ b/module_test.go
@@ -58,6 +58,15 @@ func testModuleURL(n string) *url.URL {
 	return u
 }
 
+func testURL(s string) *url.URL {
+	u, err := urlhelper.Parse(s)
+	if err != nil {
+		panic(err)
+	}
+
+	return u
+}
+
 func testStorage(t *testing.T) Storage {
 	return &FolderStorage{StorageDir: tempDir(t)}
 }


### PR DESCRIPTION
As discussed in #2 I have worked on adding support for S3, I have also included the features requested in the mentioned ticket, to summarise this adds the following features:

 - Detect S3 URLS in the following formats (this means that any S3 urls will no longer be fetched using the HTTP getter)
  - `BUCKET.s3.amazonaws.com/PATH`
  - `BUCKET.s3-REGION.amazonaws.com/PATH`
  - `s3.amazonaws.com/BUCKET/PATH`
  - `s3-REGION.amazonaws.com/BUCKET/PATH`

- Also supported is the ability to override the default authentication method and the version being "getted" (this is only supported by `GetFile`). For example:
 - `s3-REGION.amazonaws.com/BUCKET/PATH?aws_access_key_id=foo&aws_access_key_secret=bar&aws_access_token=baz`
 - `s3-REGION.amazonaws.com/BUCKET/PATH?version=1234`

- Using `Get` all files with the given prefix are fetched and stored in the destination path relative to the given prefix
- Using `GetFile` fetches the given file from S3 and is stored at the destination path. As mentioned it is also possible to fetch a versioned S3 object. 

If you have any further questions/feature suggestions let me know, thanks.