### PR TITLE
Move url helper to go-getter from terraform

### DIFF
--- a/client.go
+++ b/client.go
@@ -15,7 +15,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	urlhelper "github.com/hashicorp/terraform/helper/url"
+	urlhelper "github.com/hashicorp/go-getter/helper/url"
 )
 
 // Client is a client for downloading things.

--- a/detect.go
+++ b/detect.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/hashicorp/terraform/helper/url"
+	"github.com/hashicorp/go-getter/helper/url"
 )
 
 // Detector defines the interface that an invalid URL or a URL with a blank

--- a/get_git.go
+++ b/get_git.go
@@ -8,7 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	urlhelper "github.com/hashicorp/terraform/helper/url"
+	urlhelper "github.com/hashicorp/go-getter/helper/url"
 )
 
 // GitGetter is a Getter implementation that will download a module from

--- a/get_hg.go
+++ b/get_hg.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	urlhelper "github.com/hashicorp/terraform/helper/url"
+	urlhelper "github.com/hashicorp/go-getter/helper/url"
 )
 
 // HgGetter is a Getter implementation that will download a module from

--- a/helper/url/url.go
+++ b/helper/url/url.go
@@ -1,0 +1,14 @@
+package url
+
+import (
+	"net/url"
+)
+
+// Parse parses rawURL into a URL structure.
+// The rawURL may be relative or absolute.
+//
+// Parse is a wrapper for the Go stdlib net/url Parse function, but returns
+// Windows "safe" URLs on Windows platforms.
+func Parse(rawURL string) (*url.URL, error) {
+	return parse(rawURL)
+}

--- a/helper/url/url_test.go
+++ b/helper/url/url_test.go
@@ -1,0 +1,88 @@
+package url
+
+import (
+	"runtime"
+	"testing"
+)
+
+type parseTest struct {
+	rawURL string
+	scheme string
+	host   string
+	path   string
+	str    string
+	err    bool
+}
+
+var parseTests = []parseTest{
+	{
+		rawURL: "/foo/bar",
+		scheme: "",
+		host:   "",
+		path:   "/foo/bar",
+		str:    "/foo/bar",
+		err:    false,
+	},
+	{
+		rawURL: "file:///dir/",
+		scheme: "file",
+		host:   "",
+		path:   "/dir/",
+		str:    "file:///dir/",
+		err:    false,
+	},
+}
+
+var winParseTests = []parseTest{
+	{
+		rawURL: `C:\`,
+		scheme: ``,
+		host:   ``,
+		path:   `C:/`,
+		str:    `C:/`,
+		err:    false,
+	},
+	{
+		rawURL: `file://C:\`,
+		scheme: `file`,
+		host:   ``,
+		path:   `C:/`,
+		str:    `file://C:/`,
+		err:    false,
+	},
+	{
+		rawURL: `file:///C:\`,
+		scheme: `file`,
+		host:   ``,
+		path:   `C:/`,
+		str:    `file://C:/`,
+		err:    false,
+	},
+}
+
+func TestParse(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		parseTests = append(parseTests, winParseTests...)
+	}
+	for i, pt := range parseTests {
+		url, err := Parse(pt.rawURL)
+		if err != nil && !pt.err {
+			t.Errorf("test %d: unexpected error: %s", i, err)
+		}
+		if err == nil && pt.err {
+			t.Errorf("test %d: expected an error", i)
+		}
+		if url.Scheme != pt.scheme {
+			t.Errorf("test %d: expected Scheme = %q, got %q", i, pt.scheme, url.Scheme)
+		}
+		if url.Host != pt.host {
+			t.Errorf("test %d: expected Host = %q, got %q", i, pt.host, url.Host)
+		}
+		if url.Path != pt.path {
+			t.Errorf("test %d: expected Path = %q, got %q", i, pt.path, url.Path)
+		}
+		if url.String() != pt.str {
+			t.Errorf("test %d: expected url.String() = %q, got %q", i, pt.str, url.String())
+		}
+	}
+}

--- a/helper/url/url_unix.go
+++ b/helper/url/url_unix.go
@@ -1,0 +1,11 @@
+// +build !windows
+
+package url
+
+import (
+	"net/url"
+)
+
+func parse(rawURL string) (*url.URL, error) {
+	return url.Parse(rawURL)
+}

--- a/helper/url/url_windows.go
+++ b/helper/url/url_windows.go
@@ -1,0 +1,40 @@
+package url
+
+import (
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"strings"
+)
+
+func parse(rawURL string) (*url.URL, error) {
+	// Make sure we're using "/" since URLs are "/"-based.
+	rawURL = filepath.ToSlash(rawURL)
+
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(rawURL) > 1 && rawURL[1] == ':' {
+		// Assume we're dealing with a drive letter file path where the drive
+		// letter has been parsed into the URL Scheme, and the rest of the path
+		// has been parsed into the URL Path without the leading ':' character.
+		u.Path = fmt.Sprintf("%s:%s", string(rawURL[0]), u.Path)
+		u.Scheme = ""
+	}
+
+	if len(u.Host) > 1 && u.Host[1] == ':' && strings.HasPrefix(rawURL, "file://") {
+		// Assume we're dealing with a drive letter file path where the drive
+		// letter has been parsed into the URL Host.
+		u.Path = fmt.Sprintf("%s%s", u.Host, u.Path)
+		u.Host = ""
+	}
+
+	// Remove leading slash for absolute file paths.
+	if len(u.Path) > 2 && u.Path[0] == '/' && u.Path[2] == ':' {
+		u.Path = u.Path[1:]
+	}
+
+	return u, err
+}

--- a/module_test.go
+++ b/module_test.go
@@ -8,8 +8,8 @@ import (
 	"reflect"
 	"testing"
 
+	urlhelper "github.com/hashicorp/go-getter/helper/url"
 	"github.com/hashicorp/terraform/config"
-	urlhelper "github.com/hashicorp/terraform/helper/url"
 )
 
 const fixtureDir = "./test-fixtures"


### PR DESCRIPTION
There's currently a circular dependency between `hashicorp/terraform` and `hashicorp/go-getter` caused by this package and the package is only being used in `go-getter` (based on quick `grep` & github search) so I don't see a reason why keep it in terraform.

After this is merged, another PR in terraform for removal of `helper/url` directory can be raised.

It's probably not the best solution for https://github.com/hashicorp/terraform/pull/3773 , but I think it's good to avoid circular dependencies anyway, where possible.