### PR TITLE
GetAny

### DIFF
--- a/client.go
+++ b/client.go
@@ -222,6 +222,15 @@ func (c *Client) Get() error {
 		checksumValue = b
 	}
 
+	// For now, any means file. In the future, we'll ask the getter
+	// what it thinks it is.
+	if mode == ClientModeAny {
+		mode = ClientModeFile
+
+		// Destination is the base name of the URL path
+		dst = filepath.Join(dst, filepath.Base(u.Path))
+	}
+
 	// If we're not downloading a directory, then just download the file
 	// and return.
 	if mode == ClientModeFile {

--- a/client.go
+++ b/client.go
@@ -38,11 +38,9 @@ type Client struct {
 	Dst string
 	Pwd string
 
-	// Dir, if true, tells the Client it is downloading a directory (versus
-	// a single file). This distinction is necessary since filenames and
-	// directory names follow the same format so disambiguating is impossible
-	// without knowing ahead of time.
-	Dir bool
+	// Mode is the method of download the client will use. See ClientMode
+	// for documentation.
+	Mode ClientMode
 
 	// Detectors is the list of detectors that are tried on the source.
 	// If this is nil, then the default Detectors will be used.
@@ -55,6 +53,14 @@ type Client struct {
 	// Getters is the map of protocols supported by this client. If this
 	// is nil, then the default Getters variable will be used.
 	Getters map[string]Getter
+
+	// Dir, if true, tells the Client it is downloading a directory (versus
+	// a single file). This distinction is necessary since filenames and
+	// directory names follow the same format so disambiguating is impossible
+	// without knowing ahead of time.
+	//
+	// WARNING: deprecated. If Mode is set, that will take precedence.
+	Dir bool
 }
 
 // Get downloads the configured source to the destination.

--- a/client_mode.go
+++ b/client_mode.go
@@ -1,0 +1,24 @@
+package getter
+
+// ClientMode is the mode that the client operates in.
+type ClientMode uint
+
+const (
+	ClientModeInvalid ClientMode = iota
+
+	// ClientModeAny downloads anything it can. In this mode, dst must
+	// be a directory. If src is a file, it is saved into the directory
+	// with the basename of the URL. If src is a directory or archive,
+	// it is unpacked directly into dst.
+	ClientModeAny
+
+	// ClientModeFile downloads a single file. In this mode, dst must
+	// be a file path (doesn't have to exist). src must point to a single
+	// file. It is saved as dst.
+	ClientModeFile
+
+	// ClientModeDir downloads a directory. In this mode, dst must be
+	// a directory path (doesn't have to exist). src must point to an
+	// archive or directory (such as in s3).
+	ClientModeDir
+)

--- a/get.go
+++ b/get.go
@@ -72,6 +72,21 @@ func Get(dst, src string) error {
 	}).Get()
 }
 
+// GetAny downloads a URL into the given destination. Unlike Get or
+// GetFile, both directories and files are supported.
+//
+// dst must be a directory. If src is a file, it will be downloaded
+// into dst with the basename of the URL. If src is a directory or
+// archive, it will be unpacked directly into dst.
+func GetAny(dst, src string) error {
+	return (&Client{
+		Src:     src,
+		Dst:     dst,
+		Mode:    ClientModeAny,
+		Getters: Getters,
+	}).Get()
+}
+
 // GetFile downloads the file specified by src into the path specified by
 // dst.
 func GetFile(dst, src string) error {

--- a/get_test.go
+++ b/get_test.go
@@ -115,6 +115,20 @@ func TestGetAny_archive(t *testing.T) {
 	}
 }
 
+func TestGetAny_file(t *testing.T) {
+	dst := tempDir(t)
+	u := testModule("basic-file/foo.txt")
+
+	if err := GetAny(dst, u); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	mainPath := filepath.Join(dst, "foo.txt")
+	if _, err := os.Stat(mainPath); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
 func TestGetFile(t *testing.T) {
 	dst := tempFile(t)
 	u := testModule("basic-file/foo.txt")

--- a/get_test.go
+++ b/get_test.go
@@ -100,6 +100,21 @@ func TestGet_archive(t *testing.T) {
 	}
 }
 
+func TestGetAny_archive(t *testing.T) {
+	dst := tempDir(t)
+	u := filepath.Join("./test-fixtures", "archive.tar.gz")
+	u, _ = filepath.Abs(u)
+
+	if err := GetAny(dst, u); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	mainPath := filepath.Join(dst, "main.tf")
+	if _, err := os.Stat(mainPath); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
 func TestGetFile(t *testing.T) {
 	dst := tempFile(t)
 	u := testModule("basic-file/foo.txt")

--- a/get_test.go
+++ b/get_test.go
@@ -129,6 +129,31 @@ func TestGetAny_file(t *testing.T) {
 	}
 }
 
+/*
+TODO
+func TestGetAny_dir(t *testing.T) {
+	dst := tempDir(t)
+	u := filepath.Join("./test-fixtures", "basic")
+	u, _ = filepath.Abs(u)
+
+	if err := GetAny(dst, u); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	check := []string{
+		"main.tf",
+		"foo/main.tf",
+	}
+
+	for _, name := range check {
+		mainPath := filepath.Join(dst, name)
+		if _, err := os.Stat(mainPath); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	}
+}
+*/
+
 func TestGetFile(t *testing.T) {
 	dst := tempFile(t)
 	u := testModule("basic-file/foo.txt")


### PR DESCRIPTION
`GetAny` will attempt to download a file or directory. The semantics are:

  * If the URL is a file, it downloads it into `dst` with the basename. For example, downloading "/path/foo.txt" will store it in "dst/foo.txt"

  * If the URL is an archive, it will be unpacked into `dst`.

Directories aren't currently supported but will be.