### PR TITLE
Add AppVeyor configuration for Windows testing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,16 @@
+version: "build-{branch}-{build}"
+image: Visual Studio 2015
+clone_folder: c:\gopath\github.com\hashicorp\go-getter
+environment:
+  GOPATH: c:\gopath
+install:
+- cmd: >-
+    echo %Path%
+
+    go version
+
+    go env
+
+    go get -d -v -t ./...
+build_script:
+- cmd: go test -v ./...


### PR DESCRIPTION
Example run with this configuration can be seen [here](https://ci.appveyor.com/project/hashicorp/go-getter) - test failures are currently expected on Windows and will be fixed over the next series of pull requests.