### PR TITLE
hg/windows: Fix GetFile

### DIFF
--- a/get_hg.go
+++ b/get_hg.go
@@ -71,7 +71,12 @@ func (g *HgGetter) GetFile(dst string, u *url.URL) error {
 	// Get the filename, and strip the filename from the URL so we can
 	// just get the repository directly.
 	filename := filepath.Base(u.Path)
-	u.Path = filepath.Dir(u.Path)
+	u.Path = filepath.ToSlash(filepath.Dir(u.Path))
+
+	// If we're on Windows, we need to set the host to "localhost" for hg
+	if runtime.GOOS == "windows" {
+		u.Host = "localhost"
+	}
 
 	// Get the full repository
 	if err := g.Get(td, u); err != nil {


### PR DESCRIPTION
This commit fixes the TestHgGetter_GetFile test which was failing on Windows because of a missing call to filepath.Slash and failing to set the host of the file URL to localhost, which is required for Mercurial on Windows.

NOTE: this has not fixed all of the red tests on Windows so AppVeyor failing is still expected. Prior to merging it should be verified that the "TestHgGetter_GetFile" test is passing on Windows and that Travis is passing.