### PR TITLE
Netrc support for HTTP requests

### DIFF
--- a/get.go
+++ b/get.go
@@ -46,7 +46,7 @@ var Getters map[string]Getter
 var forcedRegexp = regexp.MustCompile(`^([A-Za-z0-9]+)::(.+)$`)
 
 func init() {
-	httpGetter := new(HttpGetter)
+	httpGetter := &HttpGetter{Netrc: true}
 
 	Getters = map[string]Getter{
 		"file":  new(FileGetter),

--- a/get_http.go
+++ b/get_http.go
@@ -32,7 +32,11 @@ import (
 // The source URL, whether from the header or meta tag, must be a fully
 // formed URL. The shorthand syntax of "github.com/foo/bar" or relative
 // paths are not allowed.
-type HttpGetter struct{}
+type HttpGetter struct {
+	// Netrc, if true, will lookup and use auth information found
+	// in the user's netrc file if available.
+	Netrc bool
+}
 
 func (g *HttpGetter) Get(dst string, u *url.URL) error {
 	// Copy the URL so we can modify it

--- a/get_http.go
+++ b/get_http.go
@@ -43,9 +43,11 @@ func (g *HttpGetter) Get(dst string, u *url.URL) error {
 	var newU url.URL = *u
 	u = &newU
 
-	// Add auth from netrc if we can
-	if err := addAuthFromNetrc(u); err != nil {
-		return err
+	if g.Netrc {
+		// Add auth from netrc if we can
+		if err := addAuthFromNetrc(u); err != nil {
+			return err
+		}
 	}
 
 	// Add terraform-get to the parameter.

--- a/get_http.go
+++ b/get_http.go
@@ -43,6 +43,11 @@ func (g *HttpGetter) Get(dst string, u *url.URL) error {
 	var newU url.URL = *u
 	u = &newU
 
+	// Add auth from netrc if we can
+	if err := addAuthFromNetrc(u); err != nil {
+		return err
+	}
+
 	// Add terraform-get to the parameter.
 	q := u.Query()
 	q.Add("terraform-get", "1")

--- a/netrc.go
+++ b/netrc.go
@@ -1,0 +1,67 @@
+package getter
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"runtime"
+
+	"github.com/bgentry/go-netrc/netrc"
+	"github.com/mitchellh/go-homedir"
+)
+
+// addAuthFromNetrc adds auth information to the URL from the user's
+// netrc file if it can be found. This will only add the auth info
+// if the URL doesn't already have auth info specified and the
+// the username is blank.
+func addAuthFromNetrc(u *url.URL) error {
+	// If the URL already has auth information, do nothing
+	if u.User != nil && u.User.Username() != "" {
+		return nil
+	}
+
+	// Get the netrc file path
+	path := os.Getenv("NETRC")
+	if path == "" {
+		filename := ".netrc"
+		if runtime.GOOS == "windows" {
+			filename = "_netrc"
+		}
+
+		var err error
+		path, err = homedir.Expand("~/" + filename)
+		if err != nil {
+			return err
+		}
+	}
+
+	// If the file is not a file, then do nothing
+	if fi, err := os.Stat(path); err != nil {
+		// File doesn't exist, do nothing
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		// Some other error!
+		return err
+	} else if fi.IsDir() {
+		// File is directory, ignore
+		return nil
+	}
+
+	// Load up the netrc file
+	net, err := netrc.ParseFile(path)
+	if err != nil {
+		return fmt.Errorf("Error parsing netrc file at %q: %s", path, err)
+	}
+
+	machine := net.FindMachine(u.Host)
+	if machine == nil {
+		// Machine not found, no problem
+		return nil
+	}
+
+	// Set the user info
+	u.User = url.UserPassword(machine.Login, machine.Password)
+	return nil
+}

--- a/netrc_test.go
+++ b/netrc_test.go
@@ -1,0 +1,63 @@
+package getter
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestAddAuthFromNetrc(t *testing.T) {
+	defer tempEnv(t, "NETRC", "./test-fixtures/netrc/basic")()
+
+	u, err := url.Parse("http://example.com")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if err := addAuthFromNetrc(u); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	expected := "http://foo:bar@example.com"
+	actual := u.String()
+	if expected != actual {
+		t.Fatalf("Mismatch: %q != %q", actual, expected)
+	}
+}
+
+func TestAddAuthFromNetrc_hasAuth(t *testing.T) {
+	defer tempEnv(t, "NETRC", "./test-fixtures/netrc/basic")()
+
+	u, err := url.Parse("http://username:password@example.com")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	expected := u.String()
+	if err := addAuthFromNetrc(u); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	actual := u.String()
+	if expected != actual {
+		t.Fatalf("Mismatch: %q != %q", actual, expected)
+	}
+}
+
+func TestAddAuthFromNetrc_hasUsername(t *testing.T) {
+	defer tempEnv(t, "NETRC", "./test-fixtures/netrc/basic")()
+
+	u, err := url.Parse("http://username@example.com")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	expected := u.String()
+	if err := addAuthFromNetrc(u); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	actual := u.String()
+	if expected != actual {
+		t.Fatalf("Mismatch: %q != %q", actual, expected)
+	}
+}

--- a/test-fixtures/netrc/basic
+++ b/test-fixtures/netrc/basic
@@ -1,0 +1,3 @@
+machine example.com
+login foo
+password bar

--- a/util_test.go
+++ b/util_test.go
@@ -1,7 +1,10 @@
 package getter
 
 import (
+	"io"
+	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -18,6 +21,28 @@ func tempEnv(t *testing.T, k, v string) func() {
 	// Easy cleanup
 	return func() {
 		if err := os.Setenv(k, old); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	}
+}
+
+// tempFileContents writes a temporary file and returns the path and a function
+// to clean it up.
+func tempFileContents(t *testing.T, contents string) (string, func()) {
+	tf, err := ioutil.TempFile("", "getter")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if _, err := io.Copy(tf, strings.NewReader(contents)); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	tf.Close()
+
+	path := tf.Name()
+	return path, func() {
+		if err := os.Remove(path); err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,24 @@
+package getter
+
+import (
+	"os"
+	"testing"
+)
+
+// tempEnv sets the env var temporarily and returns a function that should
+// be deferred to clean it up.
+func tempEnv(t *testing.T, k, v string) func() {
+	old := os.Getenv(k)
+
+	// Set env
+	if err := os.Setenv(k, v); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Easy cleanup
+	return func() {
+		if err := os.Setenv(k, old); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	}
+}


### PR DESCRIPTION
This adds automatic [netrc](http://linux.die.net/man/5/netrc) support for HTTP URLs. 

Netrc is generally not recommended since auth information is stored in plaintext however it is still very much in use and in a pinch is useful to provide auth information for something you don't want to exist in the source itself. 

This PR does the following:

  * If no username is specified for an HTTP URL, netrc is checked for a matching host. If found, the auth info is automatically used

  * The host in the netrc file must be an exact match or the "default" host

  * The `NETRC` env var is respected as an alternate path 

  * Path for netrc is `$HOME/.netrc` on Unix-like systems or `%HOME%/_netrc` on Windows

**NOTE ON GIT SUPPORT:** `git` uses `curl` under the covers which automatically uses netrc (and follows the same rules above) for HTTP URLs. Therefore, go-getter doesn't need to do anything there.