### PR TITLE
FIX: Private enterprise github references

### DIFF
--- a/detect_github.go
+++ b/detect_github.go
@@ -15,9 +15,11 @@ func (d *GitHubDetector) Detect(src, _ string) (string, bool, error) {
 		return "", false, nil
 	}
 
-	if strings.HasPrefix(src, "github.com/") {
+	parts := strings.Split(strings.Split(src, "/")[0], ".")
+
+	if parts[0] == "github" && parts[len(parts)-1] == "com" {
 		return d.detectHTTP(src)
-	} else if strings.HasPrefix(src, "git@github.com:") {
+	} else if strings.HasPrefix(src, "git@") {
 		return d.detectSSH(src)
 	}
 
@@ -51,6 +53,7 @@ func (d *GitHubDetector) detectHTTP(src string) (string, bool, error) {
 func (d *GitHubDetector) detectSSH(src string) (string, bool, error) {
 	idx := strings.Index(src, ":")
 	qidx := strings.Index(src, "?")
+	hidx := strings.Index(src, "@")
 	if qidx == -1 {
 		qidx = len(src)
 	}
@@ -58,7 +61,7 @@ func (d *GitHubDetector) detectSSH(src string) (string, bool, error) {
 	var u url.URL
 	u.Scheme = "ssh"
 	u.User = url.User("git")
-	u.Host = "github.com"
+	u.Host = src[hidx+1 : idx]
 	u.Path = src[idx+1 : qidx]
 	if qidx < len(src) {
 		q, err := url.ParseQuery(src[qidx+1:])

--- a/detect_github_test.go
+++ b/detect_github_test.go
@@ -24,16 +24,56 @@ func TestGitHubDetector(t *testing.T) {
 			"github.com/hashicorp/foo.git?foo=bar",
 			"git::https://github.com/hashicorp/foo.git?foo=bar",
 		},
+		{
+			"github.xyz.com/hashicorp/terraform.git",
+			"git::https://github.xyz.com/hashicorp/terraform.git",
+		},
+		{
+			"github.xyz.com/hashicorp/terraform",
+			"git::https://github.xyz.com/hashicorp/terraform.git",
+		},
+		{
+			"github.xyz.com/hashicorp/terraform.git?ref=test-branch",
+			"git::https://github.xyz.com/hashicorp/terraform.git?ref=test-branch",
+		},
+		{
+			"github.xyz.com/hashicorp/terraform.git//modules/a",
+			"git::https://github.xyz.com/hashicorp/terraform.git///modules/a",
+		},
+		{
+			"github.xyz.com/hashicorp/terraform//modules/a",
+			"git::https://github.xyz.com/hashicorp/terraform.git///modules/a",
+		},
 
 		// SSH
 		{"git@github.com:hashicorp/foo.git", "git::ssh://git@github.com/hashicorp/foo.git"},
+		{
+			"git@github.com:org/project.git?ref=test-branch",
+			"git::ssh://git@github.com/org/project.git?ref=test-branch",
+		},
 		{
 			"git@github.com:hashicorp/foo.git//bar",
 			"git::ssh://git@github.com/hashicorp/foo.git//bar",
 		},
 		{
-			"git@github.com:hashicorp/foo.git?foo=bar",
-			"git::ssh://git@github.com/hashicorp/foo.git?foo=bar",
+			"git@github.com:org/project.git//module/a?ref=test-branch",
+			"git::ssh://git@github.com/org/project.git//module/a?ref=test-branch",
+		},
+		{
+			"git@github.xyz.com:org/project.git", 
+			"git::ssh://git@github.xyz.com/org/project.git", 
+		},
+		{
+			"git@github.xyz.com:org/project.git?ref=test-branch",
+			"git::ssh://git@github.xyz.com/org/project.git?ref=test-branch",
+		},
+		{ 
+			"git@github.xyz.com:org/project.git//module/a",
+			"git::ssh://git@github.xyz.com/org/project.git//module/a",
+		},
+		{
+			"git@github.xyz.com:org/project.git//module/a?ref=test-branch", 
+			"git::ssh://git@github.xyz.com/org/project.git//module/a?ref=test-branch", 
 		},
 	}
 
@@ -42,14 +82,14 @@ func TestGitHubDetector(t *testing.T) {
 	for i, tc := range cases {
 		output, ok, err := f.Detect(tc.Input, pwd)
 		if err != nil {
-			t.Fatalf("err: %s", err)
+			t.Fatalf("Idx: %d input: '%s' expected '%s' err: %s", i, tc.Input, tc.Output, err)
 		}
 		if !ok {
-			t.Fatal("not ok")
+			t.Fatalf("Idx: %d input: '%s' expected '%s' not ok", i, tc.Input, tc.Output,)
 		}
 
 		if output != tc.Output {
-			t.Fatalf("%d: bad: %#v", i, output)
+			t.Fatalf("Idx: %d input: '%s' expected '%s', got '%s'", i, tc.Input, tc.Output, output)
 		}
 	}
 }


### PR DESCRIPTION
I was redirected from here https://github.com/hashicorp/terraform/pull/9644

Added a few unit test cases for github detector
Removed the hardcoded domain ‘github.com’ in detectSSH() and set it from
the source
Modified the initial testing logic for HTTPS in Detect() such that
handles domain names where github is a subdomain

PS: The test cases was added by looking at the code and behavior before
my code changes and not from knowledge of use cases/expected values. My
main objective for the test cases was to ensure I don’t break the
behavior regular github.com URLs
