### PR TITLE
Implement GetAny()

### DIFF
--- a/client.go
+++ b/client.go
@@ -222,10 +222,9 @@ func (c *Client) Get() error {
 		checksumValue = b
 	}
 
-	// For now, any means file. In the future, we'll ask the getter
-	// what it thinks it is.
 	if mode == ClientModeAny {
-		mode = ClientModeFile
+		// Ask the getter which client mode to use
+		mode = g.ClientMode(u)
 
 		// Destination is the base name of the URL path
 		dst = filepath.Join(dst, filepath.Base(u.Path))

--- a/client.go
+++ b/client.go
@@ -224,7 +224,10 @@ func (c *Client) Get() error {
 
 	if mode == ClientModeAny {
 		// Ask the getter which client mode to use
-		mode = g.ClientMode(u)
+		mode, err = g.ClientMode(u)
+		if err != nil {
+			return err
+		}
 
 		// Destination is the base name of the URL path in "any" mode when
 		// a file source is detected.

--- a/client.go
+++ b/client.go
@@ -226,8 +226,11 @@ func (c *Client) Get() error {
 		// Ask the getter which client mode to use
 		mode = g.ClientMode(u)
 
-		// Destination is the base name of the URL path
-		dst = filepath.Join(dst, filepath.Base(u.Path))
+		// Destination is the base name of the URL path in "any" mode when
+		// a file source is detected.
+		if mode == ClientModeFile {
+			dst = filepath.Join(dst, filepath.Base(u.Path))
+		}
 	}
 
 	// If we're not downloading a directory, then just download the file

--- a/get.go
+++ b/get.go
@@ -35,6 +35,10 @@ type Getter interface {
 	// reference a single file. If possible, the Getter should check if
 	// the remote end contains the same file and no-op this operation.
 	GetFile(string, *url.URL) error
+
+	// ClientMode returns the mode based on the given URL. This is used to
+	// allow clients to let the getters decide which mode to use.
+	ClientMode(*url.URL) ClientMode
 }
 
 // Getters is the mapping of scheme to the Getter implementation that will

--- a/get.go
+++ b/get.go
@@ -38,7 +38,7 @@ type Getter interface {
 
 	// ClientMode returns the mode based on the given URL. This is used to
 	// allow clients to let the getters decide which mode to use.
-	ClientMode(*url.URL) ClientMode
+	ClientMode(*url.URL) (ClientMode, error)
 }
 
 // Getters is the mapping of scheme to the Getter implementation that will

--- a/get_file.go
+++ b/get_file.go
@@ -1,6 +1,9 @@
 package getter
 
-import "net/url"
+import (
+	"net/url"
+	"os"
+)
 
 // FileGetter is a Getter implementation that will download a module from
 // a file scheme.
@@ -9,6 +12,15 @@ type FileGetter struct {
 	Copy bool
 }
 
-func (g *FileGetter) ClientMode(_ *url.URL) ClientMode {
+func (g *FileGetter) ClientMode(u *url.URL) ClientMode {
+	path := u.Path
+	if u.RawPath != "" {
+		path = u.RawPath
+	}
+
+	if fi, err := os.Stat(path); err == nil && fi.IsDir() {
+		return ClientModeDir
+	}
+
 	return ClientModeFile
 }

--- a/get_file.go
+++ b/get_file.go
@@ -12,15 +12,15 @@ type FileGetter struct {
 	Copy bool
 }
 
-func (g *FileGetter) ClientMode(u *url.URL) ClientMode {
+func (g *FileGetter) ClientMode(u *url.URL) (ClientMode, error) {
 	path := u.Path
 	if u.RawPath != "" {
 		path = u.RawPath
 	}
 
 	if fi, err := os.Stat(path); err == nil && fi.IsDir() {
-		return ClientModeDir
+		return ClientModeDir, nil
 	}
 
-	return ClientModeFile
+	return ClientModeFile, nil
 }

--- a/get_file.go
+++ b/get_file.go
@@ -18,8 +18,13 @@ func (g *FileGetter) ClientMode(u *url.URL) (ClientMode, error) {
 		path = u.RawPath
 	}
 
+	fi, err := os.Stat(path)
+	if err != nil {
+		return 0, err
+	}
+
 	// Check if the source is a directory.
-	if fi, err := os.Stat(path); err == nil && fi.IsDir() {
+	if fi.IsDir() {
 		return ClientModeDir, nil
 	}
 

--- a/get_file.go
+++ b/get_file.go
@@ -1,8 +1,14 @@
 package getter
 
+import "net/url"
+
 // FileGetter is a Getter implementation that will download a module from
 // a file scheme.
 type FileGetter struct {
 	// Copy, if set to true, will copy data instead of using a symlink
 	Copy bool
+}
+
+func (g *FileGetter) ClientMode(_ *url.URL) ClientMode {
+	return ClientModeFile
 }

--- a/get_file.go
+++ b/get_file.go
@@ -18,6 +18,7 @@ func (g *FileGetter) ClientMode(u *url.URL) (ClientMode, error) {
 		path = u.RawPath
 	}
 
+	// Check if the source is a directory.
 	if fi, err := os.Stat(path); err == nil && fi.IsDir() {
 		return ClientModeDir, nil
 	}

--- a/get_file_test.go
+++ b/get_file_test.go
@@ -165,3 +165,29 @@ func TestFileGetter_percent2F(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 }
+
+func TestFileGetter_ClientMode_file(t *testing.T) {
+	g := new(FileGetter)
+
+	// Check the client mode when pointed at a file.
+	mode, err := g.ClientMode(testModuleURL("basic-file/foo.txt"))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if mode != ClientModeFile {
+		t.Fatal("expect ClientModeFile")
+	}
+}
+
+func TestFileGetter_ClientMode_dir(t *testing.T) {
+	g := new(FileGetter)
+
+	// Check the client mode when pointed at a directory.
+	mode, err := g.ClientMode(testModuleURL("basic"))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if mode != ClientModeDir {
+		t.Fatal("expect ClientModeDir")
+	}
+}

--- a/get_file_test.go
+++ b/get_file_test.go
@@ -166,6 +166,15 @@ func TestFileGetter_percent2F(t *testing.T) {
 	}
 }
 
+func TestFileGetter_ClientMode_notexist(t *testing.T) {
+	g := new(FileGetter)
+
+	u := testURL("nonexistent")
+	if _, err := g.ClientMode(u); err == nil {
+		t.Fatal("expect source file error")
+	}
+}
+
 func TestFileGetter_ClientMode_file(t *testing.T) {
 	g := new(FileGetter)
 

--- a/get_file_unix.go
+++ b/get_file_unix.go
@@ -55,7 +55,7 @@ func (g *FileGetter) GetFile(dst string, u *url.URL) error {
 		path = u.RawPath
 	}
 
-	// The source path must exist and be a directory to be usable.
+	// The source path must exist and be a file to be usable.
 	if fi, err := os.Stat(path); err != nil {
 		return fmt.Errorf("source path error: %s", err)
 	} else if fi.IsDir() {

--- a/get_git.go
+++ b/get_git.go
@@ -15,8 +15,8 @@ import (
 // a git repository.
 type GitGetter struct{}
 
-func (g *GitGetter) ClientMode(_ *url.URL) ClientMode {
-	return ClientModeDir
+func (g *GitGetter) ClientMode(_ *url.URL) (ClientMode, error) {
+	return ClientModeDir, nil
 }
 
 func (g *GitGetter) Get(dst string, u *url.URL) error {

--- a/get_git.go
+++ b/get_git.go
@@ -15,6 +15,10 @@ import (
 // a git repository.
 type GitGetter struct{}
 
+func (g *GitGetter) ClientMode(_ *url.URL) ClientMode {
+	return ClientModeDir
+}
+
 func (g *GitGetter) Get(dst string, u *url.URL) error {
 	if _, err := exec.LookPath("git"); err != nil {
 		return fmt.Errorf("git must be available and on the PATH")

--- a/get_hg.go
+++ b/get_hg.go
@@ -16,6 +16,10 @@ import (
 // a Mercurial repository.
 type HgGetter struct{}
 
+func (g *HgGetter) ClientMode(_ *url.URL) ClientMode {
+	return ClientModeDir
+}
+
 func (g *HgGetter) Get(dst string, u *url.URL) error {
 	if _, err := exec.LookPath("hg"); err != nil {
 		return fmt.Errorf("hg must be available and on the PATH")

--- a/get_hg.go
+++ b/get_hg.go
@@ -16,8 +16,8 @@ import (
 // a Mercurial repository.
 type HgGetter struct{}
 
-func (g *HgGetter) ClientMode(_ *url.URL) ClientMode {
-	return ClientModeDir
+func (g *HgGetter) ClientMode(_ *url.URL) (ClientMode, error) {
+	return ClientModeDir, nil
 }
 
 func (g *HgGetter) Get(dst string, u *url.URL) error {

--- a/get_http.go
+++ b/get_http.go
@@ -38,11 +38,11 @@ type HttpGetter struct {
 	Netrc bool
 }
 
-func (g *HttpGetter) ClientMode(u *url.URL) ClientMode {
+func (g *HttpGetter) ClientMode(u *url.URL) (ClientMode, error) {
 	if strings.HasSuffix(u.Path, "/") {
-		return ClientModeDir
+		return ClientModeDir, nil
 	}
-	return ClientModeFile
+	return ClientModeFile, nil
 }
 
 func (g *HttpGetter) Get(dst string, u *url.URL) error {

--- a/get_http.go
+++ b/get_http.go
@@ -38,6 +38,13 @@ type HttpGetter struct {
 	Netrc bool
 }
 
+func (g *HttpGetter) ClientMode(u *url.URL) ClientMode {
+	if strings.HasSuffix(u.Path, "/") {
+		return ClientModeDir
+	}
+	return ClientModeFile
+}
+
 func (g *HttpGetter) Get(dst string, u *url.URL) error {
 	// Copy the URL so we can modify it
 	var newU url.URL = *u

--- a/get_mock.go
+++ b/get_mock.go
@@ -43,3 +43,10 @@ func (g *MockGetter) GetFile(dst string, u *url.URL) error {
 	}
 	return g.GetFileErr
 }
+
+func (g *MockGetter) ClientMode(u *url.URL) ClientMode {
+	if u.Path[len(u.Path)-1:] == "/" {
+		return ClientModeDir
+	}
+	return ClientModeFile
+}

--- a/get_mock.go
+++ b/get_mock.go
@@ -45,7 +45,7 @@ func (g *MockGetter) GetFile(dst string, u *url.URL) error {
 }
 
 func (g *MockGetter) ClientMode(u *url.URL) (ClientMode, error) {
-	if u.Path[len(u.Path)-1:] == "/" {
+	if l := len(u.Path); l > 0 && u.Path[l-1:] == "/" {
 		return ClientModeDir, nil
 	}
 	return ClientModeFile, nil

--- a/get_mock.go
+++ b/get_mock.go
@@ -44,9 +44,9 @@ func (g *MockGetter) GetFile(dst string, u *url.URL) error {
 	return g.GetFileErr
 }
 
-func (g *MockGetter) ClientMode(u *url.URL) ClientMode {
+func (g *MockGetter) ClientMode(u *url.URL) (ClientMode, error) {
 	if u.Path[len(u.Path)-1:] == "/" {
-		return ClientModeDir
+		return ClientModeDir, nil
 	}
-	return ClientModeFile
+	return ClientModeFile, nil
 }

--- a/get_s3.go
+++ b/get_s3.go
@@ -27,15 +27,16 @@ func (g *S3Getter) ClientMode(u *url.URL) (ClientMode, error) {
 		return 0, err
 	}
 
+	// Create client config
 	config := g.getAWSConfig(region, creds)
 	sess := session.New(config)
 	client := s3.New(sess)
 
+	// List the object(s) at the given prefix
 	req := &s3.ListObjectsInput{
 		Bucket: aws.String(bucket),
 		Prefix: aws.String(path),
 	}
-
 	resp, err := client.ListObjects(req)
 	if err != nil {
 		return 0, err
@@ -54,7 +55,7 @@ func (g *S3Getter) ClientMode(u *url.URL) (ClientMode, error) {
 	}
 
 	// There was no match, so just return file mode. The download is going
-	// to fail but we will let S3 return the proper error.
+	// to fail but we will let S3 return the proper error later.
 	return ClientModeFile, nil
 }
 

--- a/get_s3.go
+++ b/get_s3.go
@@ -42,10 +42,19 @@ func (g *S3Getter) ClientMode(u *url.URL) (ClientMode, error) {
 	}
 
 	for _, o := range resp.Contents {
+		// Use file mode on exact match.
+		if *o.Key == path {
+			return ClientModeFile, nil
+		}
+
+		// Use dir mode if child keys are found.
 		if strings.HasPrefix(*o.Key, path+"/") {
 			return ClientModeDir, nil
 		}
 	}
+
+	// There was no match, so just return file mode. The download is going
+	// to fail but we will let S3 return the proper error.
 	return ClientModeFile, nil
 }
 

--- a/get_s3.go
+++ b/get_s3.go
@@ -20,6 +20,10 @@ import (
 // a S3 bucket.
 type S3Getter struct{}
 
+func (g *S3Getter) ClientMode(_ *url.URL) ClientMode {
+	return ClientModeDir
+}
+
 func (g *S3Getter) Get(dst string, u *url.URL) error {
 	// Parse URL
 	region, bucket, path, _, creds, err := g.parseUrl(u)

--- a/get_s3.go
+++ b/get_s3.go
@@ -20,8 +20,8 @@ import (
 // a S3 bucket.
 type S3Getter struct{}
 
-func (g *S3Getter) ClientMode(_ *url.URL) ClientMode {
-	return ClientModeDir
+func (g *S3Getter) ClientMode(u *url.URL) (ClientMode, error) {
+	return ClientModeFile, nil
 }
 
 func (g *S3Getter) Get(dst string, u *url.URL) error {

--- a/get_s3.go
+++ b/get_s3.go
@@ -41,8 +41,10 @@ func (g *S3Getter) ClientMode(u *url.URL) (ClientMode, error) {
 		return 0, err
 	}
 
-	if len(resp.Contents) > 1 {
-		return ClientModeDir, nil
+	for _, o := range resp.Contents {
+		if strings.HasPrefix(*o.Key, path+"/") {
+			return ClientModeDir, nil
+		}
 	}
 	return ClientModeFile, nil
 }

--- a/get_s3_test.go
+++ b/get_s3_test.go
@@ -16,8 +16,8 @@ func init() {
 	// We do the string concat below to avoid AWS autodetection of a key. This
 	// key is locked down an IAM policy that is read-only so we're purposely
 	// exposing it.
-	os.Setenv("AWS_ACCESS_KEY", "AKIAJCTNQ" + "IOBWAYXKGZA")
-	os.Setenv("AWS_SECRET_KEY", "jcQOTYdXNzU5MO" + "5ExqbE1U995dIfKCKQtiVobMvr")
+	os.Setenv("AWS_ACCESS_KEY", "AKIAJCTNQ"+"IOBWAYXKGZA")
+	os.Setenv("AWS_SECRET_KEY", "jcQOTYdXNzU5MO"+"5ExqbE1U995dIfKCKQtiVobMvr")
 }
 
 func TestS3Getter_impl(t *testing.T) {
@@ -104,5 +104,33 @@ func TestS3Getter_GetFile_notfound(t *testing.T) {
 		dst, testURL("https://s3.amazonaws.com/hc-oss-test/go-getter/folder/404.tf"))
 	if err == nil {
 		t.Fatalf("expected error, got none")
+	}
+}
+
+func TestS3ClientMode_file(t *testing.T) {
+	g := new(S3Getter)
+
+	// Check client mode on a key prefix with only a single key.
+	mode, err := g.ClientMode(
+		testURL("https://s3.amazonaws.com/hc-oss-test/go-getter/folder"))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if mode != ClientModeDir {
+		t.Fatal("expect ClientModeDir")
+	}
+}
+
+func TestS3ClientMode_dir(t *testing.T) {
+	g := new(S3Getter)
+
+	// Check client mode on a key prefix which contains sub-keys.
+	mode, err := g.ClientMode(
+		testURL("https://s3.amazonaws.com/hc-oss-test/go-getter/folder/main.tf"))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if mode != ClientModeFile {
+		t.Fatal("expect ClientModeFile")
 	}
 }

--- a/get_test.go
+++ b/get_test.go
@@ -144,8 +144,6 @@ func TestGetAny_file(t *testing.T) {
 	}
 }
 
-/*
-TODO
 func TestGetAny_dir(t *testing.T) {
 	dst := tempDir(t)
 	u := filepath.Join("./test-fixtures", "basic")
@@ -167,7 +165,6 @@ func TestGetAny_dir(t *testing.T) {
 		}
 	}
 }
-*/
 
 func TestGetFile(t *testing.T) {
 	dst := tempFile(t)


### PR DESCRIPTION
Implements the getter-selected client mode when `ClientModeAny` or `GetAny()` are used. This comes with the caveat that clients may be depending on the currently-implemented `ClientModeAny`, which simply assumes everything is a file. This behavior seems broken anyways, so hopefully this isn't a big deal.

/cc @mitchellh

Fixes #35, #25