### PR TITLE
Support providing SSH keys during git clones

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,12 @@ None
     a commit SHA, a branch name, etc. If it is a named ref such as a branch
     name, go-getter will update it to the latest on each get.
 
+  * `sshkey` - An SSH private key to use during clones. The provided key must
+    be a base64-encoded string. For example, to generate a suitable `sshkey`
+    from a private key file on disk, you would run `base64 -w0 <file>`.
+
+    **Note**: Git 2.3+ is required to use this feature.
+
 ### Mercurial (`hg`)
 
   * `rev` - The Mercurial revision to checkout.

--- a/get_git.go
+++ b/get_git.go
@@ -49,7 +49,7 @@ func (g *GitGetter) Get(dst string, u *url.URL) error {
 			return err
 		}
 
-		// Write the raw key into a file.
+		// Create a temp file for the key and ensure it is removed.
 		fh, err := ioutil.TempFile("", "go-getter")
 		if err != nil {
 			return err
@@ -57,14 +57,15 @@ func (g *GitGetter) Get(dst string, u *url.URL) error {
 		sshKeyFile = fh.Name()
 		defer os.Remove(sshKeyFile)
 
-		_, err = fh.Write(raw)
-		fh.Close()
-		if err != nil {
+		// Set the permissions prior to writing the key material.
+		if err := os.Chmod(sshKeyFile, 0600); err != nil {
 			return err
 		}
 
-		// Set the permissions
-		if err := os.Chmod(sshKeyFile, 0600); err != nil {
+		// Write the raw key into the temp file.
+		_, err = fh.Write(raw)
+		fh.Close()
+		if err != nil {
 			return err
 		}
 	}

--- a/get_git.go
+++ b/get_git.go
@@ -167,8 +167,7 @@ func addSSHKeyFile(cmd *exec.Cmd, sshKeyFile string) {
 	if sshKeyFile == "" {
 		return
 	}
-	cmd.Env = append(
-		os.Environ(),
-		fmt.Sprintf("GIT_SSH_COMMAND=ssh -i %s", sshKeyFile),
-	)
+	cmd.Env = append(os.Environ(), "GIT_SSH_COMMAND=ssh "+
+		"-o StrictHostKeyChecking=no "+
+		"-i "+sshKeyFile)
 }

--- a/get_git_test.go
+++ b/get_git_test.go
@@ -1,6 +1,8 @@
 package getter
 
 import (
+	"encoding/base64"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -229,3 +231,59 @@ func TestGitGetter_GetFile(t *testing.T) {
 	}
 	assertContents(t, dst, "Hello\n")
 }
+
+func TestGitGetter_sshKey(t *testing.T) {
+	if !testHasGit {
+		t.Log("git not found, skipping")
+		t.Skip()
+	}
+
+	g := new(GitGetter)
+	dst := tempDir(t)
+
+	encodedKey := base64.StdEncoding.EncodeToString([]byte(testGitToken))
+
+	u, err := url.Parse("ssh://git@github.com/hashicorp/test-private-repo" +
+		"?sshkey=" + encodedKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := g.Get(dst, u); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	readmePath := filepath.Join(dst, "README.md")
+	if _, err := os.Stat(readmePath); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
+// This is a read-only deploy key for an empty test repository.
+var testGitToken = `-----BEGIN RSA PRIVATE KEY-----
+MIIEpgIBAAKCAQEArGJ7eweUMiT58m424ZHLu6UordeoTcOTPEMeOjIL2GuVhPU+
+Y6sdW3gMKEYFKo5ywXxVgNo8VCI8Ny8+PPfR+BNJaAI+VYNDU5rvD3ecfIjH3We4
+VyRbT/PcxNK1XJcE260P6nVXrnNLJQBbsP6tjqSswwVy/9gCiI0aa4GxvK4R1ZPJ
+H6ONYXzwgYR0QAH6jhyENe5skbH+40fT2u/I3z99HggqKOCJpgq9JkAWdXdqJPO7
+kcGP6I6lTE1Cjpi7GEuVx6iWeflmX3uveOLTJohVkhAzGxIk5rIgbqkDoiNJ1RFl
+MxFCc/LkmqdYiW6DgrWZJhlY9wB+YFWi3O/2BwIDAQABAoIBAQCE9LROcMsBXfmV
+3SHhGqUrRjg41NOPnt+JpC7FLeJq+pdo5ApJrynGabHewhqr9xBVYUNFTY0oSvts
+iLiVJ4K/tohwewJ+y+36ps3pfRSqDIkyoBPSykzPPsQw3l9ZWXU6xaE38Wc+Othj
+YoJV4igUk7hX9nT7FSznCwWsk2x1m/w40PVDeWp0VOqGz407oPpirL8wS6yxwrcL
+IR/XtEXOiOoJmHMdxlNwVOTdMz5mtCGJcl2IqjLZLP0az0SxAkTLrDeR+R9tTY/T
+cbdZS3aBVi/9pXQ9yG+QcVrV1PKGdSzOoS1QB0746n9qW4pM93PoRkeENBAM44Gx
+zJvanaqRAoGBANU7HbhkUzBiotEhFlf4uQ3cKFzlSMoJAX27OKR8MDD2vLEL0lBv
+biYBntMBU/L3A7nr/oVHJRS3dGVEoJdmvoXB+eCpNhyYiZKDXrPfaY3ifRKvcIoq
+XuWYkIGB0X1Djf7Sj6ruSxcm8y6M4l2kQq7bo7HXHvJuPRuG930OzAopAoGBAM72
+A0+3xTQrzbHcffPJPw8GUvk8tVmypHojQyXdX283GDW7LYvHd+x6rCNDIdXiZ25L
+M3YKEcZMPpjnjEH5CRUHyubocelyRiz7P2Hwj3MOSO5g11nLbSlkLYvoG4uuH8ck
+2trIRJ81OnVwwIj61CNMCG3CyYk6GN5ShDCJNWSvAoGBAKScyKrrOJWn8A4GvxsW
+9rXOepKMp47hOPd5q5bAEOwb7zu25pwWCjDpG1XGNqrhK01C9PCrJeNCZWcwfdGk
+Df1w7JkVyKJ21+314Qx3syNH8EqWigkAANa62wQ/1hwgJOTOZP8Oi4XKGf6b4L1t
+69TV1x+Z9Vgu5pnzregrnjVRAoGBAIm1KhjmB4KiTti1BN2sn5fItnb+jRClDEn0
+op5UQUcIGsTNyg2C6Onh6h4AckgVwIqj4Rb+tjsCyngFQc83/HIQ4FJqgjk5/zW4
+68CoR1rgO2jZ6RDnibgL3z6Db6iucJiajkEbFoX07fPs1T+P3o2p7sXR4TW9AYUU
+1L5S3cMjAoGBAKd+zv8xjwN9bw9wGz3l/5lWni6muXpmJ7a43Hj562jspb+moMqM
+thGypwYJHZX05VkSk8iXvZehE+Czj6xu9P5FtxKCWgMT6hc8qvCq4n41Ndx59zkN
+yuFmGAiAN8bAZgSQYyIUnWENsqFJNkj/HHR4MA/O2gY1zPq/PFCvQ9Q4
+-----END RSA PRIVATE KEY-----`


### PR DESCRIPTION
Adds an `?sshkey` query parameter which can be used to supply a private key during git clones over SSH. Use of this feature obviously requires some scrutiny. I think this is just enough to be useful while matching the general flow we have already.