### PR TITLE
Better clone performance without the git history

### DIFF
--- a/get_git.go
+++ b/get_git.go
@@ -140,7 +140,8 @@ func (g *GitGetter) checkout(dst string, ref string) error {
 }
 
 func (g *GitGetter) clone(dst, sshKeyFile string, u *url.URL) error {
-	cmd := exec.Command("git", "clone", "--depth", "1", u.String(), dst)
+	args := []string{"clone", "--depth", "1"}
+	cmd := exec.Command("git", args, u.String(), dst)
 	addSSHKeyFile(cmd, sshKeyFile)
 	return getRunCommand(cmd)
 }

--- a/get_git.go
+++ b/get_git.go
@@ -140,7 +140,7 @@ func (g *GitGetter) checkout(dst string, ref string) error {
 }
 
 func (g *GitGetter) clone(dst, sshKeyFile string, u *url.URL) error {
-	cmd := exec.Command("git", "clone", u.String(), dst)
+	cmd := exec.Command("git", "clone", "--depth", "1", u.String(), dst)
 	addSSHKeyFile(cmd, sshKeyFile)
 	return getRunCommand(cmd)
 }


### PR DESCRIPTION
The bigger the repo, the longer it takes. Especially useful for `terraform get`.