### PR TITLE
Set SSH BatchMode=yes when cloning git over ssh

### DIFF
--- a/get_git.go
+++ b/get_git.go
@@ -180,15 +180,11 @@ func (g *GitGetter) fetchSubmodules(dst, sshKeyFile string) error {
 // setupGitEnv sets up the environment for the given command. This is used to
 // pass configuration data to git and ssh and enables advanced cloning methods.
 func setupGitEnv(cmd *exec.Cmd, sshKeyFile string) {
-	sshOpts := []string{
-		// Batch mode prevents ssh from prompting for usernames, passwords, or
-		// adding hosts into a known hosts file.
-		"-o BatchMode=yes",
-	}
+	var sshOpts []string
 
 	if sshKeyFile != "" {
 		// We have an SSH key temp file configured, tell ssh about this.
-		sshOpts = append(sshOpts, "-i "+sshKeyFile)
+		sshOpts = append(sshOpts, "-i", sshKeyFile)
 	}
 
 	cmd.Env = append(os.Environ(),

--- a/get_git_test.go
+++ b/get_git_test.go
@@ -294,6 +294,28 @@ func TestGitGetter_submodule(t *testing.T) {
 	}
 }
 
+func TestGitGetter_setupGitEnv(t *testing.T) {
+	cmd := exec.Command("git")
+	setupGitEnv(cmd, "")
+	for _, v := range cmd.Env {
+		if v == "GIT_SSH_COMMAND=ssh -o BatchMode=yes" {
+			return
+		}
+	}
+	t.Fatalf("expect default options to be set: %v", cmd.Env)
+}
+
+func TestGitGetter_setupGitEnv_sshKey(t *testing.T) {
+	cmd := exec.Command("git")
+	setupGitEnv(cmd, "/tmp/foo.pem")
+	for _, v := range cmd.Env {
+		if v == "GIT_SSH_COMMAND=ssh -o BatchMode=yes -i /tmp/foo.pem" {
+			return
+		}
+	}
+	t.Fatalf("expect default options to be set: %#v", cmd.Env)
+}
+
 // gitRepo is a helper struct which controls a single temp git repo.
 type gitRepo struct {
 	t   *testing.T

--- a/get_git_test.go
+++ b/get_git_test.go
@@ -294,26 +294,16 @@ func TestGitGetter_submodule(t *testing.T) {
 	}
 }
 
-func TestGitGetter_setupGitEnv(t *testing.T) {
-	cmd := exec.Command("git")
-	setupGitEnv(cmd, "")
-	for _, v := range cmd.Env {
-		if v == "GIT_SSH_COMMAND=ssh -o BatchMode=yes" {
-			return
-		}
-	}
-	t.Fatalf("expect default options to be set: %v", cmd.Env)
-}
-
 func TestGitGetter_setupGitEnv_sshKey(t *testing.T) {
-	cmd := exec.Command("git")
+	cmd := exec.Command("/bin/sh", "-c", "echo -n $GIT_SSH_COMMAND")
 	setupGitEnv(cmd, "/tmp/foo.pem")
-	for _, v := range cmd.Env {
-		if v == "GIT_SSH_COMMAND=ssh -o BatchMode=yes -i /tmp/foo.pem" {
-			return
-		}
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatal(err)
 	}
-	t.Fatalf("expect default options to be set: %#v", cmd.Env)
+	if string(out) != "ssh -i /tmp/foo.pem" {
+		t.Fatalf("unexpected GIT_SSH_COMMAND: %q", string(out))
+	}
 }
 
 // gitRepo is a helper struct which controls a single temp git repo.


### PR DESCRIPTION
Sets the `BatchMode=yes` SSH option to prevent SSH from doing interactive prompts during `git clone`.

This also refactors some of the SSH env var handling to match what we were already doing prior to the `?sshkey` feature in #43, and fixes a bug where we didn't set up the SSH key during submodule fetches.