### PR TITLE
Git test should use "echo" and trim space locally

### DIFF
--- a/get_git_test.go
+++ b/get_git_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -296,6 +297,11 @@ func TestGitGetter_submodule(t *testing.T) {
 }
 
 func TestGitGetter_setupGitEnv_sshKey(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skipf("skipping on windows since the test requires sh")
+		return
+	}
+
 	cmd := exec.Command("/bin/sh", "-c", "echo $GIT_SSH_COMMAND")
 	setupGitEnv(cmd, "/tmp/foo.pem")
 	out, err := cmd.Output()

--- a/get_git_test.go
+++ b/get_git_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -295,14 +296,16 @@ func TestGitGetter_submodule(t *testing.T) {
 }
 
 func TestGitGetter_setupGitEnv_sshKey(t *testing.T) {
-	cmd := exec.Command("/bin/sh", "-c", "echo -n $GIT_SSH_COMMAND")
+	cmd := exec.Command("/bin/sh", "-c", "echo $GIT_SSH_COMMAND")
 	setupGitEnv(cmd, "/tmp/foo.pem")
 	out, err := cmd.Output()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(out) != "ssh -i /tmp/foo.pem" {
-		t.Fatalf("unexpected GIT_SSH_COMMAND: %q", string(out))
+
+	actual := strings.TrimSpace(string(out))
+	if actual != "ssh -i /tmp/foo.pem" {
+		t.Fatalf("unexpected GIT_SSH_COMMAND: %q", actual)
 	}
 }
 


### PR DESCRIPTION
On macOS this test was failing for me since "echo" for /bin/sh doesn't
support "-n". I think the easiest solution is to just do that behavior
locally.