### PR TITLE
Fix missing NETRC in get_http/GetFile

### DIFF
--- a/get_http.go
+++ b/get_http.go
@@ -98,6 +98,14 @@ func (g *HttpGetter) Get(dst string, u *url.URL) error {
 }
 
 func (g *HttpGetter) GetFile(dst string, u *url.URL) error {
+
+	if g.Netrc {
+		// Add auth from netrc if we can
+		if err := addAuthFromNetrc(u); err != nil {
+			return err
+		}
+	}
+
 	resp, err := http.Get(u.String())
 	if err != nil {
 		return err


### PR DESCRIPTION
It was present only in `Get`, not in `GetFile`. And Nomad uses `GetFile` so no NETRC in Nomad so far.