### PR TITLE
Drop dependency on test from package

### DIFF
--- a/decompress_bzip2_test.go
+++ b/decompress_bzip2_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestBzip2Decompressor(t *testing.T) {
-	cases := []TestDecompressCase{
+	cases := []decompressTestCase{
 		{
 			"single.bz2",
 			false,
@@ -28,5 +28,5 @@ func TestBzip2Decompressor(t *testing.T) {
 		cases[i].Input = filepath.Join("./test-fixtures", "decompress-bz2", tc.Input)
 	}
 
-	TestDecompressor(t, new(Bzip2Decompressor), cases)
+	decompressorTest(t, new(Bzip2Decompressor), cases)
 }

--- a/decompress_gzip_test.go
+++ b/decompress_gzip_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestGzipDecompressor(t *testing.T) {
-	cases := []TestDecompressCase{
+	cases := []decompressTestCase{
 		{
 			"single.gz",
 			false,
@@ -28,5 +28,5 @@ func TestGzipDecompressor(t *testing.T) {
 		cases[i].Input = filepath.Join("./test-fixtures", "decompress-gz", tc.Input)
 	}
 
-	TestDecompressor(t, new(GzipDecompressor), cases)
+	decompressorTest(t, new(GzipDecompressor), cases)
 }

--- a/decompress_tbz2_test.go
+++ b/decompress_tbz2_test.go
@@ -8,7 +8,7 @@ import (
 func TestTarBzip2Decompressor(t *testing.T) {
 	orderingPaths := []string{"workers/", "workers/mq/", "workers/mq/__init__.py"}
 
-	cases := []TestDecompressCase{
+	cases := []decompressTestCase{
 		{
 			"empty.tar.bz2",
 			false,
@@ -63,5 +63,5 @@ func TestTarBzip2Decompressor(t *testing.T) {
 		cases[i].Input = filepath.Join("./test-fixtures", "decompress-tbz2", tc.Input)
 	}
 
-	TestDecompressor(t, new(TarBzip2Decompressor), cases)
+	decompressorTest(t, new(TarBzip2Decompressor), cases)
 }

--- a/decompress_test.go
+++ b/decompress_test.go
@@ -14,8 +14,8 @@ import (
 	"testing"
 )
 
-// TestDecompressCase is a single test case for testing decompressors
-type TestDecompressCase struct {
+// decompressTestCase is a single test case for testing decompressors
+type decompressTestCase struct {
 	Input   string   // Input is the complete path to the input file
 	Dir     bool     // Dir is whether or not we're testing directory mode
 	Err     bool     // Err is whether we expect an error or not
@@ -23,8 +23,8 @@ type TestDecompressCase struct {
 	FileMD5 string   // FileMD5 is the expected MD5 for a single file
 }
 
-// TestDecompressor is a helper function for testing generic decompressors.
-func TestDecompressor(t *testing.T, d Decompressor, cases []TestDecompressCase) {
+// decompressorTest is a helper function for testing generic decompressors.
+func decompressorTest(t *testing.T, d Decompressor, cases []decompressTestCase) {
 	for _, tc := range cases {
 		t.Logf("Testing: %s", tc.Input)
 

--- a/decompress_tgz_test.go
+++ b/decompress_tgz_test.go
@@ -10,7 +10,7 @@ func TestTarGzipDecompressor(t *testing.T) {
 	multiplePaths := []string{"dir/", "dir/test2", "test1"}
 	orderingPaths := []string{"workers/", "workers/mq/", "workers/mq/__init__.py"}
 
-	cases := []TestDecompressCase{
+	cases := []decompressTestCase{
 		{
 			"empty.tar.gz",
 			false,
@@ -73,5 +73,5 @@ func TestTarGzipDecompressor(t *testing.T) {
 		cases[i].Input = filepath.Join("./test-fixtures", "decompress-tgz", tc.Input)
 	}
 
-	TestDecompressor(t, new(TarGzipDecompressor), cases)
+	decompressorTest(t, new(TarGzipDecompressor), cases)
 }

--- a/decompress_zip_test.go
+++ b/decompress_zip_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestZipDecompressor(t *testing.T) {
-	cases := []TestDecompressCase{
+	cases := []decompressTestCase{
 		{
 			"empty.zip",
 			false,
@@ -76,5 +76,5 @@ func TestZipDecompressor(t *testing.T) {
 		cases[i].Input = filepath.Join("./test-fixtures", "decompress-zip", tc.Input)
 	}
 
-	TestDecompressor(t, new(ZipDecompressor), cases)
+	decompressorTest(t, new(ZipDecompressor), cases)
 }


### PR DESCRIPTION
Currently importing `go-getter` or any package that depends on it introduces a dependency on `testing`. If you happen to be using the inbuilt `flags` package this results in the `testing` flags polluting usage. It's also generally considered not to be good practice to depend on `testing` in non-test code.