### PR TITLE
Use cleanhttp for the default http.Client

### DIFF
--- a/get.go
+++ b/get.go
@@ -51,10 +51,12 @@ var Getters map[string]Getter
 // syntax is schema::url, example: git::https://foo.com
 var forcedRegexp = regexp.MustCompile(`^([A-Za-z0-9]+)::(.+)$`)
 
+// httpClient is the default client to be used by HttpGetters.
+var httpClient = cleanhttp.DefaultClient()
+
 func init() {
 	httpGetter := &HttpGetter{
-		Netrc:  true,
-		Client: cleanhttp.DefaultClient(),
+		Netrc: true,
 	}
 
 	Getters = map[string]Getter{

--- a/get.go
+++ b/get.go
@@ -18,6 +18,8 @@ import (
 	"os/exec"
 	"regexp"
 	"syscall"
+
+	cleanhttp "github.com/hashicorp/go-cleanhttp"
 )
 
 // Getter defines the interface that schemes must implement to download
@@ -50,7 +52,10 @@ var Getters map[string]Getter
 var forcedRegexp = regexp.MustCompile(`^([A-Za-z0-9]+)::(.+)$`)
 
 func init() {
-	httpGetter := &HttpGetter{Netrc: true}
+	httpGetter := &HttpGetter{
+		Netrc:  true,
+		Client: cleanhttp.DefaultClient(),
+	}
 
 	Getters = map[string]Getter{
 		"file":  new(FileGetter),

--- a/get_http.go
+++ b/get_http.go
@@ -36,6 +36,10 @@ type HttpGetter struct {
 	// Netrc, if true, will lookup and use auth information found
 	// in the user's netrc file if available.
 	Netrc bool
+
+	// Client is the http.Client to use for Get requests.
+	// This defaults to http.DefaultClient if left unset.
+	Client *http.Client
 }
 
 func (g *HttpGetter) ClientMode(u *url.URL) (ClientMode, error) {
@@ -57,13 +61,17 @@ func (g *HttpGetter) Get(dst string, u *url.URL) error {
 		}
 	}
 
+	if g.Client == nil {
+		g.Client = http.DefaultClient
+	}
+
 	// Add terraform-get to the parameter.
 	q := u.Query()
 	q.Add("terraform-get", "1")
 	u.RawQuery = q.Encode()
 
 	// Get the URL
-	resp, err := http.Get(u.String())
+	resp, err := g.Client.Get(u.String())
 	if err != nil {
 		return err
 	}
@@ -106,7 +114,11 @@ func (g *HttpGetter) GetFile(dst string, u *url.URL) error {
 		}
 	}
 
-	resp, err := http.Get(u.String())
+	if g.Client == nil {
+		g.Client = http.DefaultClient
+	}
+
+	resp, err := g.Client.Get(u.String())
 	if err != nil {
 		return err
 	}

--- a/get_http.go
+++ b/get_http.go
@@ -38,7 +38,7 @@ type HttpGetter struct {
 	Netrc bool
 
 	// Client is the http.Client to use for Get requests.
-	// This defaults to http.DefaultClient if left unset.
+	// This defaults to a cleanhttp.DefaultClient if left unset.
 	Client *http.Client
 }
 
@@ -62,7 +62,7 @@ func (g *HttpGetter) Get(dst string, u *url.URL) error {
 	}
 
 	if g.Client == nil {
-		g.Client = http.DefaultClient
+		g.Client = httpClient
 	}
 
 	// Add terraform-get to the parameter.
@@ -115,7 +115,7 @@ func (g *HttpGetter) GetFile(dst string, u *url.URL) error {
 	}
 
 	if g.Client == nil {
-		g.Client = http.DefaultClient
+		g.Client = httpClient
 	}
 
 	resp, err := g.Client.Get(u.String())


### PR DESCRIPTION
Since go-getter uses the `http.DefaultClient` for http requests, it's behavior may be inadvertently altered by other packages modifying the Client. 

Use `cleanhttp.DefaultClient` to get a new client instance. 