### PR TITLE
Add the ability to use minio with s3 getter

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,8 +231,8 @@ characters, including the username and password, must be URL encoded.
 ### S3 (`s3`)
 
 S3 takes various access configurations in the URL. Note that it will also
-read these from standard AWS environment variables if they're set. If
-the query parameters are present, these take priority.
+read these from standard AWS environment variables if they're set. S3 compliant servers like Minio
+are also supported. If the query parameters are present, these take priority.
 
   * `aws_access_key_id` - AWS access key.
   * `aws_access_key_secret` - AWS access key secret.
@@ -244,6 +244,14 @@ If you use go-getter and want to use an EC2 IAM Instance Profile to avoid
 using credentials, then just omit these and the profile, if available will
 be used automatically.
 
+### Using S3 with Minio
+ If you use go-gitter for Minio support, you must consider the following:
+
+  * `aws_access_key_id` (required) - Minio access key.
+  * `aws_access_key_secret` (required) - Minio access key secret.
+  * `region` (optional - defaults to us-east-1) - Region identifier to use.
+  * `version` (optional - fefaults to Minio default) - Configuration file format.
+
 #### S3 Bucket Examples
 
 S3 has several addressing schemes used to reference your bucket. These are
@@ -254,4 +262,5 @@ Some examples for these addressing schemes:
 - s3::https://s3-eu-west-1.amazonaws.com/bucket/foo
 - bucket.s3.amazonaws.com/foo
 - bucket.s3-eu-west-1.amazonaws.com/foo/bar
+- "s3::http://127.0.0.1:9000/test-bucket/hello.txt?aws_access_key_id=KEYID&aws_access_key_secret=SECRETKEY&region=us-east-2"
 

--- a/get_s3.go
+++ b/get_s3.go
@@ -28,7 +28,7 @@ func (g *S3Getter) ClientMode(u *url.URL) (ClientMode, error) {
 	}
 
 	// Create client config
-	config := g.getAWSConfig(region, creds)
+	config := g.getAWSConfig(region, u, creds)
 	sess := session.New(config)
 	client := s3.New(sess)
 
@@ -84,7 +84,7 @@ func (g *S3Getter) Get(dst string, u *url.URL) error {
 		return err
 	}
 
-	config := g.getAWSConfig(region, creds)
+	config := g.getAWSConfig(region, u, creds)
 	sess := session.New(config)
 	client := s3.New(sess)
 
@@ -139,7 +139,7 @@ func (g *S3Getter) GetFile(dst string, u *url.URL) error {
 		return err
 	}
 
-	config := g.getAWSConfig(region, creds)
+	config := g.getAWSConfig(region, u, creds)
 	sess := session.New(config)
 	client := s3.New(sess)
 	return g.getObject(client, dst, bucket, path, version)
@@ -174,7 +174,7 @@ func (g *S3Getter) getObject(client *s3.S3, dst, bucket, key, version string) er
 	return err
 }
 
-func (g *S3Getter) getAWSConfig(region string, creds *credentials.Credentials) *aws.Config {
+func (g *S3Getter) getAWSConfig(region string, url *url.URL, creds *credentials.Credentials) *aws.Config {
 	conf := &aws.Config{}
 	if creds == nil {
 		// Grab the metadata URL
@@ -195,6 +195,14 @@ func (g *S3Getter) getAWSConfig(region string, creds *credentials.Credentials) *
 			})
 	}
 
+	if creds != nil {
+		conf.Endpoint = &url.Host
+		conf.S3ForcePathStyle = aws.Bool(true)
+		if url.Scheme == "http" {
+			conf.DisableSSL = aws.Bool(true)
+		}
+	}
+
 	conf.Credentials = creds
 	if region != "" {
 		conf.Region = aws.String(region)
@@ -204,29 +212,42 @@ func (g *S3Getter) getAWSConfig(region string, creds *credentials.Credentials) *
 }
 
 func (g *S3Getter) parseUrl(u *url.URL) (region, bucket, path, version string, creds *credentials.Credentials, err error) {
-	// Expected host style: s3.amazonaws.com. They always have 3 parts,
-	// although the first may differ if we're accessing a specific region.
-	hostParts := strings.Split(u.Host, ".")
-	if len(hostParts) != 3 {
-		err = fmt.Errorf("URL is not a valid S3 URL")
-		return
-	}
+	if strings.Contains(u.Host, "amazonaws.com") {
+		// Expected host style: s3.amazonaws.com. They always have 3 parts,
+		// although the first may differ if we're accessing a specific region.
+		hostParts := strings.Split(u.Host, ".")
+		if len(hostParts) != 3 {
+			err = fmt.Errorf("URL is not a valid S3 URL")
+			return
+		}
 
-	// Parse the region out of the first part of the host
-	region = strings.TrimPrefix(strings.TrimPrefix(hostParts[0], "s3-"), "s3")
-	if region == "" {
+		// Parse the region out of the first part of the host
+		region = strings.TrimPrefix(strings.TrimPrefix(hostParts[0], "s3-"), "s3")
+		if region == "" {
+			region = "us-east-1"
+		}
+
+		pathParts := strings.SplitN(u.Path, "/", 3)
+		if len(pathParts) != 3 {
+			err = fmt.Errorf("URL is not a valid S3 URL")
+			return
+		}
+
+		bucket = pathParts[1]
+		path = pathParts[2]
+		version = u.Query().Get("version")
+
+	} else {
+		pathParts := strings.SplitN(u.Path, "/", 3)
+		if len(pathParts) != 3 {
+			err = fmt.Errorf("URL is not a valid S3 URL")
+			return
+		}
+		bucket = pathParts[1]
+		path = pathParts[2]
+		version = u.Query().Get("version")
 		region = "us-east-1"
 	}
-
-	pathParts := strings.SplitN(u.Path, "/", 3)
-	if len(pathParts) != 3 {
-		err = fmt.Errorf("URL is not a valid S3 URL")
-		return
-	}
-
-	bucket = pathParts[1]
-	path = pathParts[2]
-	version = u.Query().Get("version")
 
 	_, hasAwsId := u.Query()["aws_access_key_id"]
 	_, hasAwsSecret := u.Query()["aws_access_key_secret"]

--- a/get_s3.go
+++ b/get_s3.go
@@ -250,6 +250,9 @@ func (g *S3Getter) parseUrl(u *url.URL) (region, bucket, path, version string, c
 		path = pathParts[2]
 		version = u.Query().Get("version")
 		region = u.Query().Get("region")
+		if region == "" {
+			region = "us-east-1"
+		}
 	}
 
 	_, hasAwsId := u.Query()["aws_access_key_id"]

--- a/get_s3.go
+++ b/get_s3.go
@@ -243,7 +243,7 @@ func (g *S3Getter) parseUrl(u *url.URL) (region, bucket, path, version string, c
 	} else {
 		pathParts := strings.SplitN(u.Path, "/", 3)
 		if len(pathParts) != 3 {
-			err = fmt.Errorf("URL is not a valid S3 URL")
+			err = fmt.Errorf("URL is not a valid S3 complaint URL")
 			return
 		}
 		bucket = pathParts[1]

--- a/get_s3.go
+++ b/get_s3.go
@@ -212,6 +212,9 @@ func (g *S3Getter) getAWSConfig(region string, url *url.URL, creds *credentials.
 }
 
 func (g *S3Getter) parseUrl(u *url.URL) (region, bucket, path, version string, creds *credentials.Credentials, err error) {
+	// This just check whether we are dealing with S3 or
+	// any other S3 compliant service. S3 has a predictable
+	// url as others do not
 	if strings.Contains(u.Host, "amazonaws.com") {
 		// Expected host style: s3.amazonaws.com. They always have 3 parts,
 		// although the first may differ if we're accessing a specific region.
@@ -246,7 +249,7 @@ func (g *S3Getter) parseUrl(u *url.URL) (region, bucket, path, version string, c
 		bucket = pathParts[1]
 		path = pathParts[2]
 		version = u.Query().Get("version")
-		region = "us-east-1"
+		region = u.Query().Get("region")
 	}
 
 	_, hasAwsId := u.Query()["aws_access_key_id"]

--- a/get_s3_test.go
+++ b/get_s3_test.go
@@ -169,22 +169,19 @@ func TestS3Getter_ClientMode_collision(t *testing.T) {
 	}
 }
 
-type parseTest struct {
+var s3tests = []struct {
 	url     string
 	region  string
 	bucket  string
 	path    string
 	version string
-}
-
-var s3tests = []parseTest{
-	{
-		url:     "s3::https://s3-eu-west-1.amazonaws.com/bucket/foo/bar.baz?version=1234",
-		region:  "eu-west-1",
-		bucket:  "bucket",
-		path:    "foo/bar.baz",
-		version: "1234",
-	},
+}{{
+	url:     "s3::https://s3-eu-west-1.amazonaws.com/bucket/foo/bar.baz?version=1234",
+	region:  "eu-west-1",
+	bucket:  "bucket",
+	path:    "foo/bar.baz",
+	version: "1234",
+},
 	{
 		url:     "s3::http://127.0.0.1:9000/test-bucket/hello.txt?aws_access_key_id=TESTID&aws_access_key_secret=TestSecret&region=us-east-2&version=1",
 		region:  "us-east-2",


### PR DESCRIPTION
This is an attempt at adding S3 compliant server support for the S3 protocol. I only tested with minio and it seemed to work

```bash

C:\go\src\github.com\hashicorp\go-getter\cmd\go-getter>go run main.go "s3::http://127.0.0.1:9000/test-bucket/hello.txt?aws_access_key_id=xxx&aws_access_key_secret=xxx" C:\
minio\

2017/06/17 01:37:26 Success!
```
I wasn't exactly sure how to add a unit test for it considering i would need to have a minio server running. Any feedback on the code would be great!


Closes #52 