### PR TITLE
don't escape subdirs in Detect

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -72,12 +72,18 @@ func Detect(src string, pwd string, ds []Detector) (string, error) {
 				subDir = detectSubdir
 			}
 		}
+
 		if subDir != "" {
 			u, err := url.Parse(result)
 			if err != nil {
 				return "", fmt.Errorf("Error parsing URL: %s", err)
 			}
 			u.Path += "//" + subDir
+
+			// a subdir may contain wildcards, but in order to support them we
+			// have to ensure the path isn't escaped.
+			u.RawPath = u.Path
+
 			result = u.String()
 		}
 

--- a/detect_test.go
+++ b/detect_test.go
@@ -37,6 +37,12 @@ func TestDetect(t *testing.T) {
 			"git::https://github.com/hashicorp/consul.git",
 			false,
 		},
+		{
+			"./foo/archive//*",
+			"/bar",
+			"file:///bar/foo/archive//*",
+			false,
+		},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
Subdir strings aren't really part of the url, and may contain `*`s, so
we need to ensure they aren't escaped during detection.