### PR TITLE
don't override GIT_SSH_COMMAND from environment

### DIFF
--- a/get_git.go
+++ b/get_git.go
@@ -180,17 +180,34 @@ func (g *GitGetter) fetchSubmodules(dst, sshKeyFile string) error {
 // setupGitEnv sets up the environment for the given command. This is used to
 // pass configuration data to git and ssh and enables advanced cloning methods.
 func setupGitEnv(cmd *exec.Cmd, sshKeyFile string) {
-	var sshOpts []string
+	gitSSHCommand := "GIT_SSH_COMMAND="
+	var sshCmd []string
+
+	env := os.Environ()
+
+	// If we have an existing GIT_SSH_COMMAND, we need to append our options.
+	// We will also remove our old entry to make sure the behavior is the same
+	// with versions of Go < 1.9.
+	for i, v := range env {
+		if strings.HasPrefix(v, gitSSHCommand) {
+			sshCmd = []string{v}
+
+			env[i], env[len(env)-1] = env[len(env)-1], env[i]
+			env = env[:len(env)-1]
+		}
+	}
+
+	if len(sshCmd) == 0 {
+		sshCmd = []string{gitSSHCommand + "ssh"}
+	}
 
 	if sshKeyFile != "" {
 		// We have an SSH key temp file configured, tell ssh about this.
-		sshOpts = append(sshOpts, "-i", sshKeyFile)
+		sshCmd = append(sshCmd, "-i", sshKeyFile)
 	}
 
-	cmd.Env = append(os.Environ(),
-		// Set the ssh command to use for clones.
-		"GIT_SSH_COMMAND=ssh "+strings.Join(sshOpts, " "),
-	)
+	env = append(env, strings.Join(sshCmd, " "))
+	cmd.Env = env
 }
 
 // checkGitVersion is used to check the version of git installed on the system

--- a/get_git_test.go
+++ b/get_git_test.go
@@ -315,6 +315,29 @@ func TestGitGetter_setupGitEnv_sshKey(t *testing.T) {
 	}
 }
 
+func TestGitGetter_setupGitEnvWithExisting_sshKey(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skipf("skipping on windows since the test requires sh")
+		return
+	}
+
+	// start with an existing ssh command configuration
+	os.Setenv("GIT_SSH_COMMAND", "ssh -o StrictHostKeyChecking=no")
+	defer os.Setenv("GIT_SSH_COMMAND", "")
+
+	cmd := exec.Command("/bin/sh", "-c", "echo $GIT_SSH_COMMAND")
+	setupGitEnv(cmd, "/tmp/foo.pem")
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	actual := strings.TrimSpace(string(out))
+	if actual != "ssh -o StrictHostKeyChecking=no -i /tmp/foo.pem" {
+		t.Fatalf("unexpected GIT_SSH_COMMAND: %q", actual)
+	}
+}
+
 // gitRepo is a helper struct which controls a single temp git repo.
 type gitRepo struct {
 	t   *testing.T


### PR DESCRIPTION
The behavior of duplicate environment variables was previously
undefined, so in go1.9 the exec package was updated to specify that the
last instance of a variable wins, allowing for the expected behavior
when overriding a variable.

Rather than appending the GIT_SSH_COMMAND to the Command environment,
which would override previous settings, check the process environment
first, and append our options to any existing command.