### PR TITLE
break after finding the first GIT_SSH_COMMAND

### DIFF
--- a/get_git.go
+++ b/get_git.go
@@ -193,6 +193,7 @@ func setupGitEnv(cmd *exec.Cmd, sshKeyFile string) {
 
 			env[i], env[len(env)-1] = env[len(env)-1], env[i]
 			env = env[:len(env)-1]
+			break
 		}
 	}
 


### PR DESCRIPTION
Add a break after removing GIT_SSH_COMMAND from the env slice.
While this version works and takes the last GIT_SSH_COMMAND line in the
slice, the re-assignment and re-swap looks confusing.

We shouldn't get betting duplicate env vars anyway, and this appears
like it's a bug, and is likely to confuse someone later. Just break
early as expected.