### PR TITLE
Add `?filename` param for naming file downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,9 @@ The options below are available to all protocols:
   * `checksum` - Checksum to verify the downloaded file or archive. See
     the entire section on checksumming above for format and more details.
 
+  * `filename` - When in file download mode, allows specifying the name of the
+    downloaded file on disk. Has no effect in directory mode.
+
 ### Local Files (`file`)
 
 None

--- a/client.go
+++ b/client.go
@@ -232,7 +232,18 @@ func (c *Client) Get() error {
 		// Destination is the base name of the URL path in "any" mode when
 		// a file source is detected.
 		if mode == ClientModeFile {
-			dst = filepath.Join(dst, filepath.Base(u.Path))
+			filename := filepath.Base(u.Path)
+
+			// Determine if we have a custom file name
+			if v := q.Get("filename"); v != "" {
+				// Delete the query parameter if we have it.
+				q.Del("filename")
+				u.RawQuery = q.Encode()
+
+				filename = v
+			}
+
+			dst = filepath.Join(dst, filename)
 		}
 	}
 

--- a/get_test.go
+++ b/get_test.go
@@ -362,3 +362,19 @@ func TestGetFile_checksumURL(t *testing.T) {
 		t.Fatalf("bad: %s", v)
 	}
 }
+
+func TestGetFile_filename(t *testing.T) {
+	dst := tempDir(t)
+	u := testModule("basic-file/foo.txt")
+
+	u += "?filename=bar.txt"
+
+	if err := GetAny(dst, u); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	mainPath := filepath.Join(dst, "bar.txt")
+	if _, err := os.Stat(mainPath); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}


### PR DESCRIPTION
Allows naming the downloaded file when in file mode.