### PR TITLE
Ranged requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,12 @@ None
   * `rev` - The Mercurial revision to checkout.
 
 ### HTTP (`http`)
+  * `ranged_request_bytes` - If the server supports range requests, this will
+  set the `Range` header when making the HTTP request, allowing you to specify
+  a specific range of bytes to download.
+  Example usage: `http://www.path/2/my/file.iso?ranged_request_bytes=5555-66666`,
+  or `http://www.path/2/my/file.iso?ranged_request_bytes=5555-` which will
+  request byte 5555 to EOF.
 
 #### Basic Authentication
 


### PR DESCRIPTION
Add capability to handle ranged http requests.  based heavily off Packer's current download code.

**TODO before merge** (based on PR feedback below):
- [x] implement actual download tests using ranged requests and a dummy file
- [x] Clean up logic and error related to bad ranged request resulting in full file download
- [x] Add comment clarifying why we're allocating http.NewRequest up front
- [x] move error check for rangeErr earlier and make sure to address edge case mentioned https://github.com/hashicorp/go-getter/pull/90/- files/4c10796653a5da59662524ba3c9d7d261af4dc61#r157674731
- [x] remove unnecessary parens on l 145
- [x] log when HEAD request fails -- If we intend to ignore errors and download the full file, we should probably at least log that the HEAD - request failed so range request will be ignored.
- [x] validate whether if resp.StatusCode != 200 && !(isPartialDownload && resp.StatusCode == 206)` will work on line 166
- [x] don't export getByteRange (lowercase it)
- [x] document getByteRange with comment (see https://github.com/hashicorp/go-getter/pull/90/- files/4c10796653a5da59662524ba3c9d7d261af4dc61#r157673072)
- [x] remove bytes_range_retval and just return nil, nil or nil, error.
- [x] make errMsg a package scoped constant at bottom of file
- [x] make sure that errMsg doesn't obscure actual error by wrapping a new error
- [x] turn tests into a table test. 