### PR TITLE
Check File.Close error for get_http.go 

### DIFF
--- a/get_http.go
+++ b/get_http.go
@@ -135,9 +135,14 @@ func (g *HttpGetter) GetFile(dst string, u *url.URL) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
 
-	_, err = io.Copy(f, resp.Body)
+	n, err := io.Copy(f, resp.Body)
+	if err == nil && n < resp.ContentLength {
+		err = io.ErrShortWrite
+	}
+	if err1 := f.Close(); err == nil {
+		err = err1
+	}
 	return err
 }
 


### PR DESCRIPTION
File.Close() could fail. According to close() system call, the following error could happen:
       EBADF  fd isn't a valid open file descriptor.
       EINTR  The close() call was interrupted by a signal; see signal(7).
       EIO    An I/O error occurred.

