### PR TITLE
Preserve accesstime and modifytime only when valid

### DIFF
--- a/decompress_testing.go
+++ b/decompress_testing.go
@@ -72,9 +72,13 @@ func TestDecompressor(t testing.T, d Decompressor, cases []TestDecompressCase) {
 
 				if tc.Mtime != nil {
 					actual := fi.ModTime()
-					expected := *tc.Mtime
-					if actual != expected {
-						t.Fatalf("err %s: expected mtime '%s' for %s, got '%s'", tc.Input, expected.String(), dst, actual.String())
+					if tc.Mtime.Unix() > 0 {
+						expected := *tc.Mtime
+						if actual != expected {
+							t.Fatalf("err %s: expected mtime '%s' for %s, got '%s'", tc.Input, expected.String(), dst, actual.String())
+						}
+					} else if actual.Unix() <= 0 {
+						t.Fatalf("err %s: expected mtime to be > 0, got '%s'", actual.String())
 					}
 				}
 
@@ -103,10 +107,15 @@ func TestDecompressor(t testing.T, d Decompressor, cases []TestDecompressCase) {
 						t.Fatalf("err: %s", err)
 					}
 					actual := fi.ModTime()
-					expected := *tc.Mtime
-					if actual != expected {
-						t.Fatalf("err %s: expected mtime '%s' for %s, got '%s'", tc.Input, expected.String(), path, actual.String())
+					if tc.Mtime.Unix() > 0 {
+						expected := *tc.Mtime
+						if actual != expected {
+							t.Fatalf("err %s: expected mtime '%s' for %s, got '%s'", tc.Input, expected.String(), path, actual.String())
+						}
+					} else if actual.Unix() < 0 {
+						t.Fatalf("err %s: expected mtime to be > 0, got '%s'", actual.String())
 					}
+
 				}
 			}
 		}()


### PR DESCRIPTION
This PR fixes a change in behavior introduced in https://github.com/hashicorp/go-getter/commit/0a8cdac4da1802174ae5302600ff948b6a855349 that preserves access time and modified time. This causes problems with usages of go getter in environments where the files were created with 
 no access time, reported by a user in https://github.com/hashicorp/nomad/issues/4194. 

Instead, we set the access/modify time to current time if its <=0, so that its less distruptive to client apps that rely on go-getterh

cc @dadgar @chelseakomlo 