### PR TITLE
Use a new AWS access key

### DIFF
--- a/get_s3_test.go
+++ b/get_s3_test.go
@@ -17,8 +17,8 @@ func init() {
 	// We do the string concat below to avoid AWS autodetection of a key. This
 	// key is locked down an IAM policy that is read-only so we're purposely
 	// exposing it.
-	os.Setenv("AWS_ACCESS_KEY", "AKIAJCTNQ"+"IOBWAYXKGZA")
-	os.Setenv("AWS_SECRET_KEY", "jcQOTYdXNzU5MO"+"5ExqbE1U995dIfKCKQtiVobMvr")
+	os.Setenv("AWS_ACCESS_KEY", "AKIAITTDR"+"WY2STXOZE2A")
+	os.Setenv("AWS_SECRET_KEY", "oMwSyqdass2kPF"+"/7ORZA9dlb/iegz+89B0Cy01Ea")
 }
 
 func TestS3Getter_impl(t *testing.T) {


### PR DESCRIPTION
The current AWS access key was flagged and we need to rotate it. This access key is locked down with the same IAM permissions. I looked into a couple of ways that we might be able to avoid this issue in the future, but they aren't trivial so this is at least the temporary fix.