### PR TITLE
release binaries to github

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: true
 
 addons:
   apt:
@@ -6,6 +6,7 @@ addons:
       - sourceline: 'ppa:git-core/ppa'
     packages:
       - git
+      - upx-ucl
 
 language: go
 
@@ -21,3 +22,26 @@ branches:
 matrix:
   allow_failures:
     - go: master
+
+jobs:
+  include:
+    - stage: test
+      script: make test
+    - stage: package
+      script: make package
+stages:
+  - name: test
+  - name: package
+    if: env(TRAVIS_GO_VERSION) = 1.9.x
+
+deploy:
+  provider: releases
+  api_key: $GITHUB_TOKEN
+  file:
+    - go-getter_osx
+    - go-getter.exe
+    - go-getter
+  skip_cleanup: true
+  on:
+    tag: true
+    condition: $TRAVIS_GO_VERSION =~ ^1\.9\.[0-9]+$

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+test:
+	go get -d -v -t ./...
+	go test -v ./...
+
+
+package:
+	go get github.com/mitchellh/gox
+	gox -os="darwin linux windows" -arch="amd64" ./cmd/go-getter
+	upx go-getter_*
+	mv go-getter_darwin_amd64  go-getter_osx
+	mv go-getter_linux_amd64  go-getter
+	mv go-getter_windows_amd64.exe  go-getter.exe


### PR DESCRIPTION
This PR will automatically publish binaries to Github for every tag see https://github.com/moshloop/go-getter/releases

This makes installing and using go-getter as a cli tool much easier