### PR TITLE
don't get file when checksum of destination is valid

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,9 @@ is shown below:
 The checksum query parameter is never sent to the backend protocol
 implementation. It is used at a higher level by go-getter itself.
 
+If the destination file exists and the checksums match: download
+will be skipped.
+
 ### Unarchiving
 
 go-getter will automatically unarchive files into a file or directory

--- a/client.go
+++ b/client.go
@@ -248,14 +248,23 @@ func (c *Client) Get() error {
 	// If we're not downloading a directory, then just download the file
 	// and return.
 	if mode == ClientModeFile {
-		err := g.GetFile(dst, u)
-		if err != nil {
-			return err
-		}
-
+		getFile := true
 		if checksumHash != nil {
-			if err := checksum(dst, checksumHash, checksumValue); err != nil {
+			if err := checksum(dst, checksumHash, checksumValue); err == nil {
+				// don't get the file if the checksum of dst is correct
+				getFile = false
+			}
+		}
+		if getFile {
+			err := g.GetFile(dst, u)
+			if err != nil {
 				return err
+			}
+
+			if checksumHash != nil {
+				if err := checksum(dst, checksumHash, checksumValue); err != nil {
+					return err
+				}
 			}
 		}
 

--- a/get_test.go
+++ b/get_test.go
@@ -378,3 +378,35 @@ func TestGetFile_filename(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 }
+
+func TestGetFile_checksumSkip(t *testing.T) {
+	dst := tempFile(t)
+	u := testModule("basic-file/foo.txt") + "?checksum=md5:09f7e02f1290be211da707a266f153b3"
+
+	getter := &MockGetter{Proxy: new(FileGetter)}
+	client := &Client{
+		Src: u,
+		Dst: dst,
+		Dir: false,
+		Getters: map[string]Getter{
+			"file": getter,
+		},
+	}
+
+	// get the file
+	if err := client.Get(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if v := getter.GetFileURL.Query().Get("checksum"); v != "" {
+		t.Fatalf("bad: %s", v)
+	}
+
+	// remove file getter as
+	// client does the skip
+	client.Getters["file"] = nil
+
+	if err := client.Get(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}

--- a/get_test.go
+++ b/get_test.go
@@ -402,11 +402,15 @@ func TestGetFile_checksumSkip(t *testing.T) {
 		t.Fatalf("bad: %s", v)
 	}
 
-	// remove file getter as
-	// client does the skip
-	client.Getters["file"] = nil
+	// remove proxy file getter and reset GetFileCalled so that we can re-test.
+	getter.Proxy = nil
+	getter.GetFileCalled = false
 
 	if err := client.Get(); err != nil {
 		t.Fatalf("err: %s", err)
+	}
+
+	if getter.GetFileCalled {
+		t.Fatalf("get should not have been called")
 	}
 }


### PR DESCRIPTION
Howdy,

It's all in the title.

This is to avoid downloading the file if it is already there and the checksum is valid.

This will help a lot in packer as we download big isos in a cache directory.