### PR TITLE
Allow SCP-style URLs for Git

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -23,6 +23,7 @@ var Detectors []Detector
 func init() {
 	Detectors = []Detector{
 		new(GitHubDetector),
+		new(GitDetector),
 		new(BitBucketDetector),
 		new(S3Detector),
 		new(FileDetector),

--- a/detect_git.go
+++ b/detect_git.go
@@ -1,0 +1,26 @@
+package getter
+
+// GitDetector implements Detector to detect Git SSH URLs such as
+// git@host.com:dir1/dir2 and converts them to proper URLs.
+type GitDetector struct{}
+
+func (d *GitDetector) Detect(src, _ string) (string, bool, error) {
+	if len(src) == 0 {
+		return "", false, nil
+	}
+
+	u, err := detectSSH(src)
+	if err != nil {
+		return "", true, err
+	}
+	if u == nil {
+		return "", false, nil
+	}
+
+	// We require the username to be "git" to assume that this is a Git URL
+	if u.User.Username() != "git" {
+		return "", false, nil
+	}
+
+	return "git::" + u.String(), true, nil
+}

--- a/detect_git_test.go
+++ b/detect_git_test.go
@@ -1,0 +1,38 @@
+package getter
+
+import (
+	"testing"
+)
+
+func TestGitDetector(t *testing.T) {
+	cases := []struct {
+		Input  string
+		Output string
+	}{
+		{"git@github.com:hashicorp/foo.git", "git::ssh://git@github.com/hashicorp/foo.git"},
+		{
+			"git@github.com:hashicorp/foo.git//bar",
+			"git::ssh://git@github.com/hashicorp/foo.git//bar",
+		},
+		{
+			"git@github.com:hashicorp/foo.git?foo=bar",
+			"git::ssh://git@github.com/hashicorp/foo.git?foo=bar",
+		},
+	}
+
+	pwd := "/pwd"
+	f := new(GitDetector)
+	for i, tc := range cases {
+		output, ok, err := f.Detect(tc.Input, pwd)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+		if !ok {
+			t.Fatal("not ok")
+		}
+
+		if output != tc.Output {
+			t.Fatalf("%d: bad: %#v", i, output)
+		}
+	}
+}

--- a/detect_git_test.go
+++ b/detect_git_test.go
@@ -11,12 +11,32 @@ func TestGitDetector(t *testing.T) {
 	}{
 		{"git@github.com:hashicorp/foo.git", "git::ssh://git@github.com/hashicorp/foo.git"},
 		{
+			"git@github.com:org/project.git?ref=test-branch",
+			"git::ssh://git@github.com/org/project.git?ref=test-branch",
+		},
+		{
 			"git@github.com:hashicorp/foo.git//bar",
 			"git::ssh://git@github.com/hashicorp/foo.git//bar",
 		},
 		{
 			"git@github.com:hashicorp/foo.git?foo=bar",
 			"git::ssh://git@github.com/hashicorp/foo.git?foo=bar",
+		},
+		{
+			"git@github.xyz.com:org/project.git",
+			"git::ssh://git@github.xyz.com/org/project.git",
+		},
+		{
+			"git@github.xyz.com:org/project.git?ref=test-branch",
+			"git::ssh://git@github.xyz.com/org/project.git?ref=test-branch",
+		},
+		{
+			"git@github.xyz.com:org/project.git//module/a",
+			"git::ssh://git@github.xyz.com/org/project.git//module/a",
+		},
+		{
+			"git@github.xyz.com:org/project.git//module/a?ref=test-branch",
+			"git::ssh://git@github.xyz.com/org/project.git//module/a?ref=test-branch",
 		},
 	}
 

--- a/detect_github.go
+++ b/detect_github.go
@@ -17,8 +17,6 @@ func (d *GitHubDetector) Detect(src, _ string) (string, bool, error) {
 
 	if strings.HasPrefix(src, "github.com/") {
 		return d.detectHTTP(src)
-	} else if strings.HasPrefix(src, "git@github.com:") {
-		return d.detectSSH(src)
 	}
 
 	return "", false, nil
@@ -46,28 +44,4 @@ func (d *GitHubDetector) detectHTTP(src string) (string, bool, error) {
 	}
 
 	return "git::" + url.String(), true, nil
-}
-
-func (d *GitHubDetector) detectSSH(src string) (string, bool, error) {
-	idx := strings.Index(src, ":")
-	qidx := strings.Index(src, "?")
-	if qidx == -1 {
-		qidx = len(src)
-	}
-
-	var u url.URL
-	u.Scheme = "ssh"
-	u.User = url.User("git")
-	u.Host = "github.com"
-	u.Path = src[idx+1 : qidx]
-	if qidx < len(src) {
-		q, err := url.ParseQuery(src[qidx+1:])
-		if err != nil {
-			return "", true, fmt.Errorf("error parsing GitHub SSH URL: %s", err)
-		}
-
-		u.RawQuery = q.Encode()
-	}
-
-	return "git::" + u.String(), true, nil
 }

--- a/detect_github_test.go
+++ b/detect_github_test.go
@@ -24,17 +24,6 @@ func TestGitHubDetector(t *testing.T) {
 			"github.com/hashicorp/foo.git?foo=bar",
 			"git::https://github.com/hashicorp/foo.git?foo=bar",
 		},
-
-		// SSH
-		{"git@github.com:hashicorp/foo.git", "git::ssh://git@github.com/hashicorp/foo.git"},
-		{
-			"git@github.com:hashicorp/foo.git//bar",
-			"git::ssh://git@github.com/hashicorp/foo.git//bar",
-		},
-		{
-			"git@github.com:hashicorp/foo.git?foo=bar",
-			"git::ssh://git@github.com/hashicorp/foo.git?foo=bar",
-		},
 	}
 
 	pwd := "/pwd"

--- a/detect_ssh.go
+++ b/detect_ssh.go
@@ -1,0 +1,49 @@
+package getter
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// Note that we do not have an SSH-getter currently so this file serves
+// only to hold the detectSSH helper that is used by other detectors.
+
+// sshPattern matches SCP-like SSH patterns (user@host:path)
+var sshPattern = regexp.MustCompile("^(?:([^@]+)@)?([^:]+):/?(.+)$")
+
+// detectSSH determines if the src string matches an SSH-like URL and
+// converts it into a net.URL compatible string. This returns nil if the
+// string doesn't match the SSH pattern.
+//
+// This function is tested indirectly via detect_git_test.go
+func detectSSH(src string) (*url.URL, error) {
+	matched := sshPattern.FindStringSubmatch(src)
+	if matched == nil {
+		return nil, nil
+	}
+
+	user := matched[1]
+	host := matched[2]
+	path := matched[3]
+	qidx := strings.Index(path, "?")
+	if qidx == -1 {
+		qidx = len(path)
+	}
+
+	var u url.URL
+	u.Scheme = "ssh"
+	u.User = url.User(user)
+	u.Host = host
+	u.Path = path[0:qidx]
+	if qidx < len(path) {
+		q, err := url.ParseQuery(path[qidx+1:])
+		if err != nil {
+			return nil, fmt.Errorf("error parsing GitHub SSH URL: %s", err)
+		}
+		u.RawQuery = q.Encode()
+	}
+
+	return &u, nil
+}

--- a/detect_test.go
+++ b/detect_test.go
@@ -1,6 +1,7 @@
 package getter
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -38,20 +39,54 @@ func TestDetect(t *testing.T) {
 			false,
 		},
 		{
+			"git::https://person@someothergit.com/foo/bar",
+			"",
+			"git::https://person@someothergit.com/foo/bar",
+			false,
+		},
+		{
+			"git::https://person@someothergit.com/foo/bar",
+			"/bar",
+			"git::https://person@someothergit.com/foo/bar",
+			false,
+		},
+		{
 			"./foo/archive//*",
 			"/bar",
 			"file:///bar/foo/archive//*",
 			false,
 		},
+
+		// https://github.com/hashicorp/go-getter/pull/124
+		{
+			"git::ssh://git@my.custom.git/dir1/dir2",
+			"",
+			"git::ssh://git@my.custom.git/dir1/dir2",
+			false,
+		},
+		{
+			"git::git@my.custom.git:dir1/dir2",
+			"/foo",
+			"git::ssh://git@my.custom.git/dir1/dir2",
+			false,
+		},
+		{
+			"git::git@my.custom.git:dir1/dir2",
+			"",
+			"git::ssh://git@my.custom.git/dir1/dir2",
+			false,
+		},
 	}
 
 	for i, tc := range cases {
-		output, err := Detect(tc.Input, tc.Pwd, Detectors)
-		if err != nil != tc.Err {
-			t.Fatalf("%d: bad err: %s", i, err)
-		}
-		if output != tc.Output {
-			t.Fatalf("%d: bad output: %s\nexpected: %s", i, output, tc.Output)
-		}
+		t.Run(fmt.Sprintf("%d %s", i, tc.Input), func(t *testing.T) {
+			output, err := Detect(tc.Input, tc.Pwd, Detectors)
+			if err != nil != tc.Err {
+				t.Fatalf("%d: bad err: %s", i, err)
+			}
+			if output != tc.Output {
+				t.Fatalf("%d: bad output: %s\nexpected: %s", i, output, tc.Output)
+			}
+		})
 	}
 }

--- a/get_git.go
+++ b/get_git.go
@@ -78,6 +78,26 @@ func (g *GitGetter) Get(dst string, u *url.URL) error {
 		}
 	}
 
+	// For SSH-style URLs, if they use the SCP syntax of host:path, then
+	// the URL will be mangled. We detect that here and correct the path.
+	// Example: host:path/bar will turn into host/path/bar
+	if u.Scheme == "ssh" {
+		if idx := strings.Index(u.Host, ":"); idx > -1 {
+			// Copy the URL so we don't modify the input
+			var newU url.URL = *u
+			u = &newU
+
+			// Path includes the part after the ':'.
+			u.Path = u.Host[idx+1:] + u.Path
+			if u.Path[0] != '/' {
+				u.Path = "/" + u.Path
+			}
+
+			// Host trims up to the :
+			u.Host = u.Host[:idx]
+		}
+	}
+
 	// Clone or update the repository
 	_, err := os.Stat(dst)
 	if err != nil && !os.IsNotExist(err) {


### PR DESCRIPTION
This fixes both #38 and #124, and should also address the 4 TF issues referenced there as well. First, thanks @paultyng for the failing cases as well as a stab at a solution. You can see I took from that! I also took the failing cases from #38 (now passing). 

I dug into the linked Terraform issues and there were actually two issues at play, both fixed in this PR:

**1.) Detector for SCP-like Git URLs:** 

The heuristic we use here is the `git@` username. We can extend this to support more usernames in the future (the code is ready for it) but all the issues seem to use this as the user and this limits the blast radius of this change significantly. 

This detects things in the form of `git@foo.com:path` and converts it to `git::ssh://git@foo.com/path` and Git will clone this properly. 

Note that if a user other than "git" is required, the go-getter user can still use full forced URLs like `git::ssh://admin@host.com/path`. 

**2.) Fixing up the SCP-like URLs directly in the Git getter:** 

If a full, valid URL is given to go-getter, then the detectors are not run. So if a user gave the URL `git::ssh://git@foo.com:path` (note the colon), then the detector won't run to fix that up at all. Therefore, I also added a little fixup directly in the Git getter that looks for 1.) an SSH URL and 2.) with ":" in the host (how Go's `net/url` parses it) and fixes it up.

This should fix the issues where the direct URL is used.

**Note to @apparentlymart:** Re: your comment, I verified that forced protocols will always force. This is done here: https://github.com/hashicorp/go-getter/blob/9fd5bfc48c2d3bc3a8251bc9c8dba824d1b02dab/detect.go#L93 So your comment should be okay, everything works as you would expect.

## Backwards Compatibility

This should not break any backwards compatibility.

These SCP-like URLs were being detected as "file" URLs below and its highly unlikely that was ever the intended behavior. Users who may have intended this can force it with `file::`, though I strongly believe the number of users impacted by that will be zero.

## Future Stuff

The groundwork is now laid (`detect_ssh.go`) to support an SCP-getter directly as well. So we can consider doing that one day by expanding this detector directly into SSH URLs that use an SCP lib or something.