### PR TITLE
Add depth query param to git getter

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,9 @@ None
     from a private key file on disk, you would run `base64 -w0 <file>`.
 
     **Note**: Git 2.3+ is required to use this feature.
+  
+  * `depth` - The Git clone depth. The provided number specifies the last `n`
+    revisions to clone from the repository.
 
 ### Mercurial (`hg`)
 

--- a/get_git_test.go
+++ b/get_git_test.go
@@ -88,6 +88,42 @@ func TestGitGetter_branch(t *testing.T) {
 	}
 }
 
+func TestGitGetter_shallowClone(t *testing.T) {
+	if !testHasGit {
+		t.Log("git not found, skipping")
+		t.Skip()
+	}
+
+	g := new(GitGetter)
+	dst := tempDir(t)
+
+	repo := testGitRepo(t, "upstream")
+	repo.commitFile("upstream.txt", "0")
+	repo.commitFile("upstream.txt", "1")
+
+	// Specifiy a clone depth of 1
+	q := repo.url.Query()
+	q.Add("depth", "1")
+	repo.url.RawQuery = q.Encode()
+
+	if err := g.Get(dst, repo.url); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Assert rev-list count is '1'
+	cmd := exec.Command("git", "rev-list", "HEAD", "--count")
+	cmd.Dir = dst
+	b, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	out := strings.TrimSpace(string(b))
+	if out != "1" {
+		t.Fatalf("expected rev-list count to be '1' but got %v", out)
+	}
+}
+
 func TestGitGetter_branchUpdate(t *testing.T) {
 	if !testHasGit {
 		t.Skip("git not found, skipping")


### PR DESCRIPTION
Resolves #127.

This basically allows including a `depth` query parameter which functions similar to the `--depth` flag for git. This will be great for shallow cloning a repository via `myRepoURI?depth=1`. I haven't set the getter to automatically shallow clone, like the issue mentioned, but if that is the preferred route I'm happy to change my code.