### PR TITLE
Update S3 to allow setting S3Acceleration config setting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ are also supported. If the query parameters are present, these take priority.
   * `aws_access_key_id` - AWS access key.
   * `aws_access_key_secret` - AWS access key secret.
   * `aws_access_token` - AWS access token if this is being used.
+  * `s3_use_accelerate` - Set this to `true` to enable S3 Accelerate feature.
 
 #### Using IAM Instance Profiles with S3
 

--- a/get_s3.go
+++ b/get_s3.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -22,13 +23,13 @@ type S3Getter struct{}
 
 func (g *S3Getter) ClientMode(u *url.URL) (ClientMode, error) {
 	// Parse URL
-	region, bucket, path, _, creds, err := g.parseUrl(u)
+	region, bucket, path, _, s3Acc, creds, err := g.parseUrl(u)
 	if err != nil {
 		return 0, err
 	}
 
 	// Create client config
-	config := g.getAWSConfig(region, u, creds)
+	config := g.getAWSConfig(region, u, s3Acc, creds)
 	sess := session.New(config)
 	client := s3.New(sess)
 
@@ -61,7 +62,7 @@ func (g *S3Getter) ClientMode(u *url.URL) (ClientMode, error) {
 
 func (g *S3Getter) Get(dst string, u *url.URL) error {
 	// Parse URL
-	region, bucket, path, _, creds, err := g.parseUrl(u)
+	region, bucket, path, _, s3Acc, creds, err := g.parseUrl(u)
 	if err != nil {
 		return err
 	}
@@ -84,7 +85,7 @@ func (g *S3Getter) Get(dst string, u *url.URL) error {
 		return err
 	}
 
-	config := g.getAWSConfig(region, u, creds)
+	config := g.getAWSConfig(region, u, s3Acc, creds)
 	sess := session.New(config)
 	client := s3.New(sess)
 
@@ -134,12 +135,12 @@ func (g *S3Getter) Get(dst string, u *url.URL) error {
 }
 
 func (g *S3Getter) GetFile(dst string, u *url.URL) error {
-	region, bucket, path, version, creds, err := g.parseUrl(u)
+	region, bucket, path, version, s3Acc, creds, err := g.parseUrl(u)
 	if err != nil {
 		return err
 	}
 
-	config := g.getAWSConfig(region, u, creds)
+	config := g.getAWSConfig(region, u, s3Acc, creds)
 	sess := session.New(config)
 	client := s3.New(sess)
 	return g.getObject(client, dst, bucket, path, version)
@@ -174,7 +175,7 @@ func (g *S3Getter) getObject(client *s3.S3, dst, bucket, key, version string) er
 	return err
 }
 
-func (g *S3Getter) getAWSConfig(region string, url *url.URL, creds *credentials.Credentials) *aws.Config {
+func (g *S3Getter) getAWSConfig(region string, url *url.URL, s3Acc bool, creds *credentials.Credentials) *aws.Config {
 	conf := &aws.Config{}
 	if creds == nil {
 		// Grab the metadata URL
@@ -208,10 +209,15 @@ func (g *S3Getter) getAWSConfig(region string, url *url.URL, creds *credentials.
 		conf.Region = aws.String(region)
 	}
 
+	if s3Acc {
+		conf.S3ForcePathStyle = aws.Bool(false)
+		conf.S3UseAccelerate = &s3Acc
+	}
+
 	return conf
 }
 
-func (g *S3Getter) parseUrl(u *url.URL) (region, bucket, path, version string, creds *credentials.Credentials, err error) {
+func (g *S3Getter) parseUrl(u *url.URL) (region, bucket, path, version string, s3Acc bool, creds *credentials.Credentials, err error) {
 	// This just check whether we are dealing with S3 or
 	// any other S3 compliant service. S3 has a predictable
 	// url as others do not
@@ -264,6 +270,15 @@ func (g *S3Getter) parseUrl(u *url.URL) (region, bucket, path, version string, c
 			u.Query().Get("aws_access_key_secret"),
 			u.Query().Get("aws_access_token"),
 		)
+	}
+
+	_, hasS3Acc := u.Query()["s3_use_accelerate"]
+	if hasS3Acc {
+		s3 := u.Query().Get("s3_use_accelerate")
+		s3Acc, err = strconv.ParseBool(s3)
+		if err != nil {
+			return
+		}
 	}
 
 	return

--- a/get_s3_test.go
+++ b/get_s3_test.go
@@ -177,22 +177,25 @@ func TestS3Getter_Url(t *testing.T) {
 		bucket  string
 		path    string
 		version string
+		s3Acc   bool
 	}{
 		{
 			name:    "AWSv1234",
-			url:     "s3::https://s3-eu-west-1.amazonaws.com/bucket/foo/bar.baz?version=1234",
+			url:     "s3::https://s3-eu-west-1.amazonaws.com/bucket/foo/bar.baz?version=1234&s3_use_accelerate=true",
 			region:  "eu-west-1",
 			bucket:  "bucket",
 			path:    "foo/bar.baz",
 			version: "1234",
+			s3Acc:   true,
 		},
 		{
 			name:    "localhost-1",
-			url:     "s3::http://127.0.0.1:9000/test-bucket/hello.txt?aws_access_key_id=TESTID&aws_access_key_secret=TestSecret&region=us-east-2&version=1",
+			url:     "s3::http://127.0.0.1:9000/test-bucket/hello.txt?aws_access_key_id=TESTID&aws_access_key_secret=TestSecret&region=us-east-2&version=1&s3_use_accelerate=true",
 			region:  "us-east-2",
 			bucket:  "test-bucket",
 			path:    "hello.txt",
 			version: "1",
+			s3Acc:   true,
 		},
 		{
 			name:    "localhost-2",
@@ -201,14 +204,16 @@ func TestS3Getter_Url(t *testing.T) {
 			bucket:  "test-bucket",
 			path:    "hello.txt",
 			version: "1",
+			s3Acc:   false,
 		},
 		{
 			name:    "localhost-3",
-			url:     "s3::http://127.0.0.1:9000/test-bucket/hello.txt?aws_access_key_id=TESTID&aws_access_key_secret=TestSecret",
+			url:     "s3::http://127.0.0.1:9000/test-bucket/hello.txt?aws_access_key_id=TESTID&aws_access_key_secret=TestSecret&s3_use_accelerate=false",
 			region:  "us-east-1",
 			bucket:  "test-bucket",
 			path:    "hello.txt",
 			version: "",
+			s3Acc:   false,
 		},
 	}
 
@@ -225,7 +230,7 @@ func TestS3Getter_Url(t *testing.T) {
 				t.Fatalf("expected forced protocol to be s3")
 			}
 
-			region, bucket, path, version, creds, err := g.parseUrl(u)
+			region, bucket, path, version, s3Acc, creds, err := g.parseUrl(u)
 
 			if err != nil {
 				t.Fatalf("err: %s", err)
@@ -244,6 +249,9 @@ func TestS3Getter_Url(t *testing.T) {
 			}
 			if &creds == nil {
 				t.Fatalf("expected to not be nil")
+			}
+			if s3Acc != pt.s3Acc {
+				t.Fatalf("expected %v, got %v", pt.s3Acc, s3Acc)
 			}
 		})
 	}


### PR DESCRIPTION
When using S3 with transfer acceleration the AWS config setting
S3UseAccelerate should be set to true. This overrides the
S3ForcePathStyle setting and allows the user to make use of the
bucket transfter acceleration.

Closes #148