### PR TITLE
make tmpFile close the newly created file in case a future task need to delete it

### DIFF
--- a/common.go
+++ b/common.go
@@ -9,5 +9,6 @@ func tmpFile(dir, pattern string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	f.Close()
 	return f.Name(), nil
 }


### PR DESCRIPTION
This could cause checksumming from file on windows to error because the go-getter would try to download to that temporary file that is still opened.
This probably worked on unix system as the system considered the process/owner as being the same.