### PR TITLE
Various fixes

### DIFF
--- a/checksum.go
+++ b/checksum.go
@@ -36,6 +36,7 @@ func (c *fileChecksum) checksum(source string) error {
 	}
 	defer f.Close()
 
+	c.Hash.Reset()
 	if _, err := io.Copy(c.Hash, f); err != nil {
 		return fmt.Errorf("Failed to hash: %s", err)
 	}

--- a/checksum.go
+++ b/checksum.go
@@ -179,13 +179,15 @@ func (c *Client) checksumFromFile(checksumFile string, src *url.URL) (*fileCheck
 	defer os.Remove(tempfile)
 
 	c2 := &Client{
-		Getters:       c.Getters,
-		Decompressors: c.Decompressors,
-		Detectors:     c.Detectors,
-		Pwd:           c.Pwd,
-		Dir:           false,
-		Src:           checksumFile,
-		Dst:           tempfile,
+		Ctx:              c.Ctx,
+		Getters:          c.Getters,
+		Decompressors:    c.Decompressors,
+		Detectors:        c.Detectors,
+		Pwd:              c.Pwd,
+		Dir:              false,
+		Src:              checksumFile,
+		Dst:              tempfile,
+		ProgressListener: c.ProgressListener,
 	}
 	if err = c2.Get(); err != nil {
 		return nil, fmt.Errorf(

--- a/get_http.go
+++ b/get_http.go
@@ -128,7 +128,7 @@ func (g *HttpGetter) Get(dst string, u *url.URL) error {
 	return g.getSubdir(ctx, dst, source, subDir)
 }
 
-func (g *HttpGetter) GetFile(dst string, src *url.URL) (err error) {
+func (g *HttpGetter) GetFile(dst string, src *url.URL) error {
 	ctx := g.Context()
 	if g.Netrc {
 		// Add auth from netrc if we can
@@ -146,12 +146,7 @@ func (g *HttpGetter) GetFile(dst string, src *url.URL) (err error) {
 	if err != nil {
 		return err
 	}
-	defer func() {
-		cerr := f.Close()
-		if err == nil {
-			err = cerr
-		}
-	}()
+	defer f.Close()
 
 	if g.Client == nil {
 		g.Client = httpClient

--- a/get_http.go
+++ b/get_http.go
@@ -128,7 +128,7 @@ func (g *HttpGetter) Get(dst string, u *url.URL) error {
 	return g.getSubdir(ctx, dst, source, subDir)
 }
 
-func (g *HttpGetter) GetFile(dst string, src *url.URL) error {
+func (g *HttpGetter) GetFile(dst string, src *url.URL) (err error) {
 	ctx := g.Context()
 	if g.Netrc {
 		// Add auth from netrc if we can
@@ -146,6 +146,12 @@ func (g *HttpGetter) GetFile(dst string, src *url.URL) error {
 	if err != nil {
 		return err
 	}
+	defer func() {
+		cerr := f.Close()
+		if err == nil {
+			err = cerr
+		}
+	}()
 
 	if g.Client == nil {
 		g.Client = httpClient
@@ -210,9 +216,6 @@ func (g *HttpGetter) GetFile(dst string, src *url.URL) error {
 	n, err := Copy(ctx, f, body)
 	if err == nil && n < resp.ContentLength {
 		err = io.ErrShortWrite
-	}
-	if err1 := f.Close(); err == nil {
-		err = err1
 	}
 	return err
 }

--- a/get_http_test.go
+++ b/get_http_test.go
@@ -213,7 +213,7 @@ func TestHttpGetter_resume(t *testing.T) {
 	}
 
 	if string(b) != string(load) {
-		t.Errorf("file differs: got:\n%s\n expected:\n%s\n", string(b), string(load))
+		t.Fatalf("file differs: got:\n%s\n expected:\n%s\n", string(b), string(load))
 	}
 
 	// Get it again

--- a/get_http_test.go
+++ b/get_http_test.go
@@ -188,7 +188,7 @@ func TestHttpGetter_resume(t *testing.T) {
 		t.Fatalf("create: %v", err)
 	}
 	if n, err := f.Write(load[:downloadFrom]); n != downloadFrom || err != nil {
-		t.Fatalf("partia file write failed: %d, %s", n, err)
+		t.Fatalf("partial file write failed: %d, %s", n, err)
 	}
 	if err := f.Close(); err != nil {
 		t.Fatalf("close failed: %s", err)

--- a/get_http_test.go
+++ b/get_http_test.go
@@ -204,7 +204,7 @@ func TestHttpGetter_resume(t *testing.T) {
 
 	// Finish getting it!
 	if err := GetFile(dst, u.String()); err != nil {
-		t.Errorf("finishing download should not error: %v", err)
+		t.Fatalf("finishing download should not error: %v", err)
 	}
 
 	b, err := ioutil.ReadFile(dst)
@@ -218,7 +218,7 @@ func TestHttpGetter_resume(t *testing.T) {
 
 	// Get it again
 	if err := GetFile(dst, u.String()); err != nil {
-		t.Errorf("should not error: %v", err)
+		t.Fatalf("should not error: %v", err)
 	}
 }
 


### PR DESCRIPTION
This is a bunch of minor fix/improvement after #136.

* passes the cancellation context and progress tracker to a checksum go-getter.
* make sure  HttpGetter.GetFile closes a fd in every case after opening one.
* reset checksum hash before checksumming as it is run before a download to see if the file is already present; this would cause the checksum to error in case the file was only partially present.