### PR TITLE
git: Handle scp-style git addresses in detector, not getter

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,16 @@ None
   * `depth` - The Git clone depth. The provided number specifies the last `n`
     revisions to clone from the repository.
 
+
+The `git` getter accepts both URL-style SSH addresses like
+`git::ssh://git@example.com/foo/bar`, and "scp-style" addresses like
+`git::git@example.com/foo/bar`. In the latter case, omitting the `git::`
+force prefix is allowed if the username prefix is exactly `git@`.
+
+The "scp-style" addresses _cannot_ be used in conjunction with the `ssh://`
+scheme prefix, because in that case the colon is used to mark an optional
+port number to connect on, rather than to delimit the path from the host.
+
 ### Mercurial (`hg`)
 
   * `rev` - The Mercurial revision to checkout.

--- a/get_git.go
+++ b/get_git.go
@@ -34,6 +34,15 @@ func (g *GitGetter) Get(dst string, u *url.URL) error {
 		return fmt.Errorf("git must be available and on the PATH")
 	}
 
+	// The port number must be parseable as an integer. If not, the user
+	// was probably trying to use a scp-style address, in which case the
+	// ssh:// prefix must be removed to indicate that.
+	if portStr := u.Port(); portStr != "" {
+		if _, err := strconv.ParseUint(portStr, 10, 16); err != nil {
+			return fmt.Errorf("invalid port number %q; if using the \"scp-like\" git address scheme where a colon introduces the path instead, remove the ssh:// portion and use just the git:: prefix", portStr)
+		}
+	}
+
 	// Extract some query parameters we use
 	var ref, sshKey string
 	var depth int
@@ -87,26 +96,6 @@ func (g *GitGetter) Get(dst string, u *url.URL) error {
 		fh.Close()
 		if err != nil {
 			return err
-		}
-	}
-
-	// For SSH-style URLs, if they use the SCP syntax of host:path, then
-	// the URL will be mangled. We detect that here and correct the path.
-	// Example: host:path/bar will turn into host/path/bar
-	if u.Scheme == "ssh" {
-		if idx := strings.Index(u.Host, ":"); idx > -1 {
-			// Copy the URL so we don't modify the input
-			var newU url.URL = *u
-			u = &newU
-
-			// Path includes the part after the ':'.
-			u.Path = u.Host[idx+1:] + u.Path
-			if u.Path[0] != '/' {
-				u.Path = "/" + u.Path
-			}
-
-			// Host trims up to the :
-			u.Host = u.Host[:idx]
 		}
 	}
 


### PR DESCRIPTION
The "scp-style" remote URL scheme in git is ambiguous with the standard URL syntax in our previous design where we'd add/accept the `ssh://` prefix in both cases; `ssh://git@example.com:222/foo` could be understood as either of the following:

- connect to `example.com` on port 222 and clone from path `foo`
- connect to `example.com` on port 22 and clone from path `222/foo`

Originally we used the first interpretation. but in #129 we switched to the second in order to support a strange hybrid form where the `ssh://` prefix could introduce scp-like form, but in the process we broke handling of the standard URL form when a non-standard port is required, as is sometimes the case for internal git servers running on machines where port 22 is already used for administrative access.

git itself resolves this ambiguity by not permitting the `ssh://` scheme to be used in conjunction with the scp-like form. Here we'll now mimic that by supporting the scp-like form _only_ in the detector, and only allowing it when the `ssh://` prefix isn't present. That allows for the following two scp-like forms to be accepted:

 - `git@example.com:foo/bar` when the username is "git", as seems common in various git server solutions
 - `git::anything@example.com:foo/bar` for any username

We no longer support using the scp-like form with the ssh:// prefix, so `git::ssh://anything.example.com:foo/bar` is invalid. To use that form, the `ssh://` part must be omitted, which is consistent with git's own behavior. **This is a breaking change to `go-getter` for scp-like addresses with the scheme and no port number, though.**

The detector already rewrites the scp-like form into the standard URL form when no `ssh:` scheme is given, so the getter does not need to do anything special to deal with it.

In the git getter, we now also check to see if the port number seems to be non-decimal and return a more actionable error if so, since that is likely to be caused by someone incorrectly using the `ssh://` scheme with a scp-style address. Explicitly prohibiting that ambiguous form seems better than breaking the ability to use non-standard port numbers.

---

This is for hashicorp/terraform#21257. As we vendor this fix into Terraform we'll also need to update its module sources documentation, which is largely a description of go-getter's behavior. Any other application that supports installing from git using `go-getter` will probably need to make similar documentation changes, as well as recording this as a breaking change.

