### PR TITLE
export checksum code

### DIFF
--- a/checksum.go
+++ b/checksum.go
@@ -115,7 +115,7 @@ func (c *Client) extractChecksum(u *url.URL) (*fileChecksum, error) {
 
 	switch checksumType {
 	case "file":
-		return c.checksumFromFile(checksumValue, u)
+		return c.ChecksumFromFile(checksumValue, u)
 	default:
 		return newChecksumFromType(checksumType, checksumValue, filepath.Base(u.EscapedPath()))
 	}
@@ -190,7 +190,7 @@ func newChecksumFromValue(checksumValue, filename string) (*fileChecksum, error)
 //
 // checksumsFromFile will only return checksums for files that match file
 // behind src
-func (c *Client) checksumFromFile(checksumFile string, src *url.URL) (*fileChecksum, error) {
+func (c *Client) ChecksumFromFile(checksumFile string, src *url.URL) (*fileChecksum, error) {
 	checksumFileURL, err := urlhelper.Parse(checksumFile)
 	if err != nil {
 		return nil, err

--- a/checksum.go
+++ b/checksum.go
@@ -19,8 +19,8 @@ import (
 	urlhelper "github.com/hashicorp/go-getter/helper/url"
 )
 
-// fileChecksum helps verifying the checksum for a file.
-type fileChecksum struct {
+// FileChecksum helps verifying the checksum for a file.
+type FileChecksum struct {
 	Type     string
 	Hash     hash.Hash
 	Value    []byte
@@ -50,7 +50,7 @@ func (cerr *ChecksumError) Error() string {
 
 // checksum is a simple method to compute the checksum of a source file
 // and compare it to the given expected value.
-func (c *fileChecksum) checksum(source string) error {
+func (c *FileChecksum) checksum(source string) error {
 	f, err := os.Open(source)
 	if err != nil {
 		return fmt.Errorf("Failed to open file for checksum: %s", err)
@@ -74,7 +74,7 @@ func (c *fileChecksum) checksum(source string) error {
 	return nil
 }
 
-// extractChecksum will return a fileChecksum based on the 'checksum'
+// extractChecksum will return a FileChecksum based on the 'checksum'
 // parameter of u.
 // ex:
 //  http://hashicorp.com/terraform?checksum=<checksumValue>
@@ -93,7 +93,7 @@ func (c *fileChecksum) checksum(source string) error {
 //  <checksum> *file2
 //
 // see parseChecksumLine for more detail on checksum file parsing
-func (c *Client) extractChecksum(u *url.URL) (*fileChecksum, error) {
+func (c *Client) extractChecksum(u *url.URL) (*FileChecksum, error) {
 	q := u.Query()
 	v := q.Get("checksum")
 
@@ -121,8 +121,8 @@ func (c *Client) extractChecksum(u *url.URL) (*fileChecksum, error) {
 	}
 }
 
-func newChecksum(checksumValue, filename string) (*fileChecksum, error) {
-	c := &fileChecksum{
+func newChecksum(checksumValue, filename string) (*FileChecksum, error) {
+	c := &FileChecksum{
 		Filename: filename,
 	}
 	var err error
@@ -133,7 +133,7 @@ func newChecksum(checksumValue, filename string) (*fileChecksum, error) {
 	return c, nil
 }
 
-func newChecksumFromType(checksumType, checksumValue, filename string) (*fileChecksum, error) {
+func newChecksumFromType(checksumType, checksumValue, filename string) (*FileChecksum, error) {
 	c, err := newChecksum(checksumValue, filename)
 	if err != nil {
 		return nil, err
@@ -157,7 +157,7 @@ func newChecksumFromType(checksumType, checksumValue, filename string) (*fileChe
 	return c, nil
 }
 
-func newChecksumFromValue(checksumValue, filename string) (*fileChecksum, error) {
+func newChecksumFromValue(checksumValue, filename string) (*FileChecksum, error) {
 	c, err := newChecksum(checksumValue, filename)
 	if err != nil {
 		return nil, err
@@ -183,14 +183,14 @@ func newChecksumFromValue(checksumValue, filename string) (*fileChecksum, error)
 	return c, nil
 }
 
-// checksumsFromFile will return all the fileChecksums found in file
+// ChecksumFromFile will return all the FileChecksums found in file
 //
-// checksumsFromFile will try to guess the hashing algorithm based on content
+// ChecksumFromFile will try to guess the hashing algorithm based on content
 // of checksum file
 //
-// checksumsFromFile will only return checksums for files that match file
+// ChecksumFromFile will only return checksums for files that match file
 // behind src
-func (c *Client) ChecksumFromFile(checksumFile string, src *url.URL) (*fileChecksum, error) {
+func (c *Client) ChecksumFromFile(checksumFile string, src *url.URL) (*FileChecksum, error) {
 	checksumFileURL, err := urlhelper.Parse(checksumFile)
 	if err != nil {
 		return nil, err
@@ -286,7 +286,7 @@ func (c *Client) ChecksumFromFile(checksumFile string, src *url.URL) (*fileCheck
 // of a line.
 // for BSD type sums parseChecksumLine guesses the hashing algorithm
 // by checking the length of the checksum.
-func parseChecksumLine(line string) (*fileChecksum, error) {
+func parseChecksumLine(line string) (*FileChecksum, error) {
 	parts := strings.Fields(line)
 
 	switch len(parts) {


### PR DESCRIPTION
Adrien wrote code to allow the go-getter to handle checksums from files, so that Packer didn't need to handle file checksums in its own internal logic. But we missed a "fun" edge case where we were using the checksum information pulled from that file to decide whether or not to _upload_ a file to a vmware esxi machine.

Packer needs to be able to access the actual checksums contained within the file. The only way to do that apart from re-implementing all of the file parsing code from go-getter for this one edge case is to allow the client to call the checksum extraction directly. 

I don't think making this method exported is a particularly bad thing, but I'd appreciate a sanity check... maybe from @vancluever who reviewed the original checksum file code.

FWIW I've tested this change within Packer and it does solve my issue.