### PR TITLE
Fix bitbucket detector

### DIFF
--- a/detect_bitbucket.go
+++ b/detect_bitbucket.go
@@ -35,7 +35,7 @@ func (d *BitBucketDetector) detectHTTP(src string) (string, bool, error) {
 	var info struct {
 		SCM string `json:"scm"`
 	}
-	infoUrl := "https://api.bitbucket.org/1.0/repositories" + u.Path
+	infoUrl := "https://api.bitbucket.org/2.0/repositories" + u.Path
 	resp, err := http.Get(infoUrl)
 	if err != nil {
 		return "", true, fmt.Errorf("error looking up BitBucket URL: %s", err)


### PR DESCRIPTION
bitbucket deprecated v1.0 of its repositories API, so our previous call to that url is now permanently returning a 410. The good news is that we can swap out for the v2.0 without any issues.