### PR TITLE
Prevent test failures for invalid SCP-style URLs in go 1.12

### DIFF
--- a/detect_git_test.go
+++ b/detect_git_test.go
@@ -42,12 +42,6 @@ func TestGitDetector(t *testing.T) {
 			"git::ssh://git@github.xyz.com/org/project.git//module/a?ref=test-branch",
 		},
 		{
-			// Using the scp-like form with the ssh:// prefix is invalid, so
-			// it passes through as-is.
-			"git::ssh://git@github.xyz.com:org/project.git",
-			"git::ssh://git@github.xyz.com:org/project.git",
-		},
-		{
 			// Already in the canonical form, so no rewriting required
 			// When the ssh: protocol is used explicitly, we recognize it as
 			// URL form rather than SCP-like form, so the part after the colon
@@ -61,7 +55,7 @@ func TestGitDetector(t *testing.T) {
 	f := new(GitDetector)
 	ds := []Detector{f}
 	for _, tc := range cases {
-		t.Run(tc.Input, func (t *testing.T) {
+		t.Run(tc.Input, func(t *testing.T) {
 			output, err := Detect(tc.Input, pwd, ds)
 			if err != nil {
 				t.Fatalf("unexpected error: %s", err)

--- a/get_git.go
+++ b/get_git.go
@@ -37,6 +37,9 @@ func (g *GitGetter) Get(dst string, u *url.URL) error {
 	// The port number must be parseable as an integer. If not, the user
 	// was probably trying to use a scp-style address, in which case the
 	// ssh:// prefix must be removed to indicate that.
+	//
+	// This is not necessary in versions of Go which have patched
+	// CVE-2019-14809 (e.g. Go 1.12.8+)
 	if portStr := u.Port(); portStr != "" {
 		if _, err := strconv.ParseUint(portStr, 10, 16); err != nil {
 			return fmt.Errorf("invalid port number %q; if using the \"scp-like\" git address scheme where a colon introduces the path instead, remove the ssh:// portion and use just the git:: prefix", portStr)

--- a/get_git_test.go
+++ b/get_git_test.go
@@ -380,7 +380,6 @@ func TestGitGetter_sshExplicitPort(t *testing.T) {
 	}
 }
 
-
 func TestGitGetter_sshSCPStyleInvalidScheme(t *testing.T) {
 	if !testHasGit {
 		t.Skip("git not found, skipping")
@@ -417,8 +416,10 @@ func TestGitGetter_sshSCPStyleInvalidScheme(t *testing.T) {
 		t.Fatalf("get succeeded; want error")
 	}
 
-	if got, want := err.Error(), `invalid port number "hashicorp"`; !strings.Contains(got, want) {
-		t.Fatalf("wrong error\ngot:  %s\nwant: %s", got, want)
+	got := err.Error()
+	want1, want2 := `invalid source string`, `invalid port number "hashicorp"`
+	if !(strings.Contains(got, want1) || strings.Contains(got, want2)) {
+		t.Fatalf("wrong error\ngot:  %s\nwant: %q or %q", got, want1, want2)
 	}
 }
 


### PR DESCRIPTION
Fixes #203

This (invalid) format was introduced in https://github.com/hashicorp/go-getter/commit/f9ec369200fd2163b8f452e5e45696d83ae3f4b6 but it was introduced in such a way that getter always treated it as invalid anyway (as mentioned in the commit message).

Detector would keep it as is, which I assume was just attempt to retain some backward compatibility, rather than intention? @apparentlymart 

That said (because `go-getter` is used as a library) if anyone already compiled this under Go 1.12.8+ then it's already "broken" for them anyway and I so I feel there's very little value in attempting to retain backward compatibility for <1.12.8 when we already broke it for many people and depending on the way folks use this library it may (probably?) even pose a risk - see https://nvd.nist.gov/vuln/detail/CVE-2019-14809 for more details about the motivation behind the patch in Go.