### PR TITLE
Fix not to set header on http client when HttpGetter.Header is nil

### DIFF
--- a/get_http.go
+++ b/get_http.go
@@ -88,7 +88,10 @@ func (g *HttpGetter) Get(dst string, u *url.URL) error {
 		return err
 	}
 
-	req.Header = g.Header
+	if g.Header != nil {
+		req.Header = g.Header
+	}
+
 	resp, err := g.Client.Do(req)
 	if err != nil {
 		return err


### PR DESCRIPTION
When TestHttpGetter_auth is executed with Go 1.13, panic occurs.

```console
$ go1.13 test -run TestHttpGetter_auth
--- FAIL: TestHttpGetter_auth (0.00s)
panic: assignment to entry in nil map [recovered]
	panic: assignment to entry in nil map

goroutine 22 [running]:
testing.tRunner.func1(0xc0003c2100)
	/Users/178inaba/sdk/go1.13/src/testing/testing.go:874 +0x3a3
panic(0x1829c80, 0x1a8ded0)
	/Users/178inaba/sdk/go1.13/src/runtime/panic.go:679 +0x1b2
net/textproto.MIMEHeader.Set(...)
	/Users/178inaba/sdk/go1.13/src/net/textproto/header.go:22
net/http.Header.Set(...)
	/Users/178inaba/sdk/go1.13/src/net/http/header.go:37
net/http.send(0xc0003e4000, 0x1aa4e40, 0xc0003a2140, 0x0, 0x0, 0x0, 0xc000010078, 0x203000, 0x1, 0x0)
	/Users/178inaba/sdk/go1.13/src/net/http/client.go:242 +0x338
net/http.(*Client).send(0xc00037b350, 0xc0003e4000, 0x0, 0x0, 0x0, 0xc000010078, 0x0, 0x1, 0x1920700)
	/Users/178inaba/sdk/go1.13/src/net/http/client.go:174 +0xfa
net/http.(*Client).do(0xc00037b350, 0xc0003e4000, 0x0, 0x0, 0x0)
	/Users/178inaba/sdk/go1.13/src/net/http/client.go:641 +0x3ce
net/http.(*Client).Do(...)
	/Users/178inaba/sdk/go1.13/src/net/http/client.go:509
github.com/hashicorp/go-getter.(*HttpGetter).Get(0xc000141ec0, 0xc0000be400, 0x3c, 0xc000071ee0, 0x0, 0x0)
	/Users/178inaba/work/go/go-getter/get_http.go:92 +0x203
github.com/hashicorp/go-getter.TestHttpGetter_auth(0xc0003c2100)
	/Users/178inaba/work/go/go-getter/get_http_test.go:265 +0x240
testing.tRunner(0xc0003c2100, 0x196c4e8)
	/Users/178inaba/sdk/go1.13/src/testing/testing.go:909 +0xc9
created by testing.(*T).Run
	/Users/178inaba/sdk/go1.13/src/testing/testing.go:960 +0x350
exit status 2
FAIL	github.com/hashicorp/go-getter	0.103s
```

The reason is that nil is set in Header of http client.
It seems that it changed to use `Header.Clone()` newly added in Go 1.13.
https://github.com/golang/go/blob/cdd2c265cc132a15e20298fbb083a70d7f3b495d/src/net/http/client.go#L241

So I added a nil check.