### PR TITLE
Add build tags for disabling s3 and gcs

### DIFF
--- a/detect_gcs.go
+++ b/detect_gcs.go
@@ -1,3 +1,5 @@
+// +build !go_getter_nogcs
+
 package getter
 
 import (

--- a/detect_gcs_no.go
+++ b/detect_gcs_no.go
@@ -1,0 +1,11 @@
+// +build go_getter_nogcs
+
+package getter
+
+// GCSDetector implements Detector to detect GCS URLs and turn
+// them into URLs that the GCSGetter can understand.
+type GCSDetector struct{}
+
+func (d *GCSDetector) Detect(src, _ string) (string, bool, error) {
+	return "", false, nil
+}

--- a/detect_gcs_test.go
+++ b/detect_gcs_test.go
@@ -1,3 +1,5 @@
+// +build !go_getter_nogcs
+
 package getter
 
 import (

--- a/detect_s3.go
+++ b/detect_s3.go
@@ -1,3 +1,5 @@
+// +build !go_getter_nos3
+
 package getter
 
 import (

--- a/detect_s3_no.go
+++ b/detect_s3_no.go
@@ -1,0 +1,11 @@
+// +build go_getter_nos3
+
+package getter
+
+// S3Detector implements Detector to detect S3 URLs and turn
+// them into URLs that the S3 getter can understand.
+type S3Detector struct{}
+
+func (d *S3Detector) Detect(src, _ string) (string, bool, error) {
+	return "", false, nil
+}

--- a/detect_s3_test.go
+++ b/detect_s3_test.go
@@ -1,3 +1,5 @@
+// +build !go_getter_nos3
+
 package getter
 
 import (

--- a/get_gcs.go
+++ b/get_gcs.go
@@ -1,3 +1,5 @@
+// +build !go_getter_nogcs
+
 package getter
 
 import (

--- a/get_gcs_no.go
+++ b/get_gcs_no.go
@@ -1,0 +1,26 @@
+// +build go_getter_nogcs
+
+package getter
+
+import (
+	"net/url"
+	"errors"
+)
+
+// GCSGetter is a Getter implementation that will download a module from
+// a GCS bucket.
+type GCSGetter struct {
+	getter
+}
+
+func (g *GCSGetter) ClientMode(u *url.URL) (ClientMode, error) {
+	return 0, errors.New("not available")
+}
+
+func (g *GCSGetter) Get(dst string, u *url.URL) error {
+	return errors.New("not available")
+}
+
+func (g *GCSGetter) GetFile(dst string, u *url.URL) error {
+	return errors.New("not available")
+}

--- a/get_gcs_test.go
+++ b/get_gcs_test.go
@@ -1,3 +1,5 @@
+// +build !go_getter_nogcs
+
 package getter
 
 import (

--- a/get_s3.go
+++ b/get_s3.go
@@ -1,3 +1,5 @@
+// +build !go_getter_nos3
+
 package getter
 
 import (

--- a/get_s3_no.go
+++ b/get_s3_no.go
@@ -1,0 +1,26 @@
+// +build go_getter_nos3
+
+package getter
+
+import (
+	"net/url"
+	"errors"
+)
+
+// S3Getter is a Getter implementation that will download a module from
+// a S3 bucket.
+type S3Getter struct {
+	getter
+}
+
+func (g *S3Getter) ClientMode(u *url.URL) (ClientMode, error) {
+	return 0, errors.New("not available")
+}
+
+func (g *S3Getter) Get(dst string, u *url.URL) error {
+	return errors.New("not available")
+}
+
+func (g *S3Getter) GetFile(dst string, u *url.URL) error {
+	return errors.New("not available")
+}

--- a/get_s3_test.go
+++ b/get_s3_test.go
@@ -1,3 +1,5 @@
+// +build !go_getter_nogcs
+
 package getter
 
 import (


### PR DESCRIPTION
-tags "go_getter_nos3 go_getter_nogcs"

Since github.com/aws/aws-sdk-go/aws and
cloud.google.com/go/storage are so big...

For #193