### PR TITLE
Add `-o IdentitiesOnly=yes` to test `GIT_SSH_COMMAND`

### DIFF
--- a/get_git_test.go
+++ b/get_git_test.go
@@ -279,7 +279,7 @@ func TestGitGetter_sshKey(t *testing.T) {
 	encodedKey := base64.StdEncoding.EncodeToString([]byte(testGitToken))
 
 	// avoid getting locked by a github authenticity validation prompt
-	os.Setenv("GIT_SSH_COMMAND", "ssh -o StrictHostKeyChecking=no")
+	os.Setenv("GIT_SSH_COMMAND", "ssh -o StrictHostKeyChecking=no -o IdentitiesOnly=yes")
 	defer os.Setenv("GIT_SSH_COMMAND", "")
 
 	u, err := urlhelper.Parse("ssh://git@github.com/hashicorp/test-private-repo" +
@@ -309,7 +309,7 @@ func TestGitGetter_sshSCPStyle(t *testing.T) {
 	encodedKey := base64.StdEncoding.EncodeToString([]byte(testGitToken))
 
 	// avoid getting locked by a github authenticity validation prompt
-	os.Setenv("GIT_SSH_COMMAND", "ssh -o StrictHostKeyChecking=no")
+	os.Setenv("GIT_SSH_COMMAND", "ssh -o StrictHostKeyChecking=no -o IdentitiesOnly=yes")
 	defer os.Setenv("GIT_SSH_COMMAND", "")
 
 	// This test exercises the combination of the git detector and the
@@ -350,7 +350,7 @@ func TestGitGetter_sshExplicitPort(t *testing.T) {
 	encodedKey := base64.StdEncoding.EncodeToString([]byte(testGitToken))
 
 	// avoid getting locked by a github authenticity validation prompt
-	os.Setenv("GIT_SSH_COMMAND", "ssh -o StrictHostKeyChecking=no")
+	os.Setenv("GIT_SSH_COMMAND", "ssh -o StrictHostKeyChecking=no -o IdentitiesOnly=yes")
 	defer os.Setenv("GIT_SSH_COMMAND", "")
 
 	// This test exercises the combination of the git detector and the
@@ -391,7 +391,7 @@ func TestGitGetter_sshSCPStyleInvalidScheme(t *testing.T) {
 	encodedKey := base64.StdEncoding.EncodeToString([]byte(testGitToken))
 
 	// avoid getting locked by a github authenticity validation prompt
-	os.Setenv("GIT_SSH_COMMAND", "ssh -o StrictHostKeyChecking=no")
+	os.Setenv("GIT_SSH_COMMAND", "ssh -o StrictHostKeyChecking=no -o IdentitiesOnly=yes")
 	defer os.Setenv("GIT_SSH_COMMAND", "")
 
 	// This test exercises the combination of the git detector and the
@@ -499,7 +499,7 @@ func TestGitGetter_setupGitEnvWithExisting_sshKey(t *testing.T) {
 	}
 
 	// start with an existing ssh command configuration
-	os.Setenv("GIT_SSH_COMMAND", "ssh -o StrictHostKeyChecking=no")
+	os.Setenv("GIT_SSH_COMMAND", "ssh -o StrictHostKeyChecking=no -o IdentitiesOnly=yes")
 	defer os.Setenv("GIT_SSH_COMMAND", "")
 
 	cmd := exec.Command("/bin/sh", "-c", "echo $GIT_SSH_COMMAND")
@@ -510,7 +510,7 @@ func TestGitGetter_setupGitEnvWithExisting_sshKey(t *testing.T) {
 	}
 
 	actual := strings.TrimSpace(string(out))
-	if actual != "ssh -o StrictHostKeyChecking=no -i /tmp/foo.pem" {
+	if actual != "ssh -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i /tmp/foo.pem" {
 		t.Fatalf("unexpected GIT_SSH_COMMAND: %q", actual)
 	}
 }


### PR DESCRIPTION
Executing test after `ssh-add` will fail.
To avoid this, we added `IdentitiesOnly=yes` to use only the key specified by ssh command.

Fail log:

```console
$ ssh-add
Identity added: /Users/178inaba/.ssh/id_rsa (178inaba@mac)
$ go test ./...
--- FAIL: TestGitGetter_sshKey (1.81s)
    get_git_test.go:292: err: /usr/local/bin/git exited with 128: Cloning into '/var/folders/wp/wd7n1rkd5ln8v4c3qsw891vnxxxxxx/T/tf220123456'...
        ERROR: Repository not found.
        fatal: Could not read from remote repository.

        Please make sure you have the correct access rights
        and the repository exists.
--- FAIL: TestGitGetter_sshSCPStyle (1.91s)
    get_git_test.go:333: client.Get failed: error downloading 'ssh://git@github.com/hashicorp/test-private-repo?sshkey=xxx': /usr/local/bin/git exited with 128: Cloning into '/var/folders/wp/wd7n1rkd5ln8v4c3qsw891vnxxxxxx/T/tf735123456'...
        ERROR: Repository not found.
        fatal: Could not read from remote repository.

        Please make sure you have the correct access rights
        and the repository exists.
--- FAIL: TestGitGetter_sshExplicitPort (1.73s)
    get_git_test.go:374: client.Get failed: error downloading 'ssh://git@github.com:22/hashicorp/test-private-repo?sshkey=xxx': /usr/local/bin/git exited with 128: Cloning into '/var/folders/wp/wd7n1rkd5ln8v4c3qsw891vnxxxxxx/T/tf470123456'...
        ERROR: Repository not found.
        fatal: Could not read from remote repository.

        Please make sure you have the correct access rights
        and the repository exists.
FAIL
FAIL	github.com/hashicorp/go-getter	19.224s
?   	github.com/hashicorp/go-getter/cmd/go-getter	[no test files]
ok  	github.com/hashicorp/go-getter/helper/url	(cached)
FAIL
```