### PR TITLE
Add go version to `go.mod`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,3 +21,5 @@ require (
 	google.golang.org/api v0.9.0
 	gopkg.in/cheggaaa/pb.v1 v1.0.27 // indirect
 )
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/hashicorp/go-getter
 
+go 1.13
+
 require (
 	cloud.google.com/go v0.45.1
 	github.com/aws/aws-sdk-go v1.15.78
@@ -21,5 +23,3 @@ require (
 	google.golang.org/api v0.9.0
 	gopkg.in/cheggaaa/pb.v1 v1.0.27 // indirect
 )
-
-go 1.13


### PR DESCRIPTION
In Go 1.13, when you execute the Go command (eg `go test`), the version is automatically added to `go.mod`.
Since a difference is generated every time test is executed, I want to commit this so that there is no difference.

Reproduction procedure:

```console
$ git diff
(No difference)
$ go test
...
$ git diff
diff --git a/go.mod b/go.mod
index a869e8f..30606f9 100644
--- a/go.mod
+++ b/go.mod
@@ -21,3 +21,5 @@ require (
 	google.golang.org/api v0.9.0
 	gopkg.in/cheggaaa/pb.v1 v1.0.27 // indirect
 )
+
+go 1.13
```