### PR TITLE
update circleci config to save mod cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,12 +25,7 @@ jobs:
       - restore_cache:
           keys:
             - go-getter-modcache-v1-{{ checksum "go.mod" }}
-
-      # Save go module cache if the go.mod file has changed
-      - save_cache:
-          key: go-getter-modcache-v1-{{ checksum "go.mod" }}
-          paths:
-            - "/go/pkg/mod"
+            - go-getter-modcache-v1
 
       # check go fmt output because it does not report non-zero when there are fmt changes
       - run:
@@ -51,6 +46,12 @@ jobs:
           path: *TEST_RESULTS_PATH
       - store_artifacts:
           path: *TEST_RESULTS_PATH
+
+      # Save go module cache if the go.mod file has changed
+      - save_cache:
+          key: go-getter-modcache-v1-{{ checksum "go.mod" }}
+          paths:
+            - "/go/pkg/mod"
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,14 @@ jobs:
       - restore_cache:
           keys:
             - go-getter-modcache-v1-{{ checksum "go.mod" }}
-            - go-getter-modcache-v1
+
+      - run: go mod download
+
+      # Save go module cache if the go.mod file has changed
+      - save_cache:
+          key: go-getter-modcache-v1-{{ checksum "go.mod" }}
+          paths:
+            - "/go/pkg/mod"
 
       # check go fmt output because it does not report non-zero when there are fmt changes
       - run:
@@ -46,12 +53,6 @@ jobs:
           path: *TEST_RESULTS_PATH
       - store_artifacts:
           path: *TEST_RESULTS_PATH
-
-      # Save go module cache if the go.mod file has changed
-      - save_cache:
-          key: go-getter-modcache-v1-{{ checksum "go.mod" }}
-          paths:
-            - "/go/pkg/mod"
 
 workflows:
   version: 2


### PR DESCRIPTION
Updating the circleci config so it will save the go mod cache in response to: https://github.com/hashicorp/go-getter/pull/214#issuecomment-540083238