### PR TITLE
Use default AWS credential handling under normal circumstances

### DIFF
--- a/get_s3.go
+++ b/get_s3.go
@@ -181,20 +181,15 @@ func (g *S3Getter) getObject(ctx context.Context, client *s3.S3, dst, bucket, ke
 
 func (g *S3Getter) getAWSConfig(region string, url *url.URL, creds *credentials.Credentials) *aws.Config {
 	conf := &aws.Config{}
-	if creds == nil {
-		// Grab the metadata URL
-		metadataURL := os.Getenv("AWS_METADATA_URL")
-		if metadataURL == "" {
-			metadataURL = "http://169.254.169.254:80/latest"
-		}
-
+	metadataURLOverride := os.Getenv("AWS_METADATA_URL")
+	if creds == nil && metadataURLOverride != "" {
 		creds = credentials.NewChainCredentials(
 			[]credentials.Provider{
 				&credentials.EnvProvider{},
 				&credentials.SharedCredentialsProvider{Filename: "", Profile: ""},
 				&ec2rolecreds.EC2RoleProvider{
 					Client: ec2metadata.New(session.New(&aws.Config{
-						Endpoint: aws.String(metadataURL),
+						Endpoint: aws.String(metadataURLOverride),
 					})),
 				},
 			})
@@ -213,7 +208,7 @@ func (g *S3Getter) getAWSConfig(region string, url *url.URL, creds *credentials.
 		conf.Region = aws.String(region)
 	}
 
-	return conf
+	return conf.WithCredentialsChainVerboseErrors(true)
 }
 
 func (g *S3Getter) parseUrl(u *url.URL) (region, bucket, path, version string, creds *credentials.Credentials, err error) {


### PR DESCRIPTION
Fixes #191 (and #185, #157, #152, #22)

This PR changes go-getter to default to the AWS SDK's built in credential resolution. This makes it possible for go-getter to download from S3 using an assumed role (e.g. when setting environment variables `AWS_SDK_LOAD_CONFIG=true AWS_PROFILE=...`, go-getter will assume that role before attempting any operations). It should also add support for various other edge cases relating to AWS credentials.

The one case where go-getter will continue to construct its own credential chain is the one with an override for the instance metadata URL. I'm not familiar with the use case of overriding the instance metadata URL, so I left that code as it was.

I'd like to add a test to protect against regressions in assume-role behavior, but I'd appreciate some guidance there. I see the hardcoded read-only IAM access key/secret. Do those credentials also have the ability to assume some role?