### PR TITLE
fix error when both ref and depth specified

### DIFF
--- a/get_git.go
+++ b/get_git.go
@@ -114,7 +114,7 @@ func (g *GitGetter) Get(dst string, u *url.URL) error {
 	if err == nil {
 		err = g.update(ctx, dst, sshKeyFile, ref, depth)
 	} else {
-		err = g.clone(ctx, dst, sshKeyFile, u, depth)
+		err = g.clone(ctx, dst, sshKeyFile, u, ref, depth)
 	}
 	if err != nil {
 		return err
@@ -166,11 +166,16 @@ func (g *GitGetter) checkout(dst string, ref string) error {
 	return getRunCommand(cmd)
 }
 
-func (g *GitGetter) clone(ctx context.Context, dst, sshKeyFile string, u *url.URL, depth int) error {
+func (g *GitGetter) clone(ctx context.Context, dst, sshKeyFile string, u *url.URL, ref string, depth int) error {
 	args := []string{"clone"}
 
 	if depth > 0 {
 		args = append(args, "--depth", strconv.Itoa(depth))
+	}
+
+	// TODO : What if ref is not a branch ?!
+	if ref != "" {
+		args = append(args, "--branch", ref)
 	}
 
 	args = append(args, u.String(), dst)


### PR DESCRIPTION
Related to Issue #225 

- g.clone doesn't define which branch to clone, so when depth is specified it's only clone master branch
- after that it tries to checkout to the branch with g.checkout(dst, ref)
- since the defined branch hasn't been cloned, it fail with the error message "error: pathspec 'XXX' did not match any file(s) known to git"