### PR TITLE
don't attempt range request without object size

### DIFF
--- a/get_http.go
+++ b/get_http.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	safetemp "github.com/hashicorp/go-safetemp"
@@ -89,7 +88,7 @@ func (g *HttpGetter) Get(dst string, u *url.URL) error {
 	}
 
 	if g.Header != nil {
-		req.Header = g.Header
+		req.Header = g.Header.Clone()
 	}
 
 	resp, err := g.Client.Do(req)
@@ -131,6 +130,12 @@ func (g *HttpGetter) Get(dst string, u *url.URL) error {
 	return g.getSubdir(ctx, dst, source, subDir)
 }
 
+// GetFile fetches the file from src and stores it at dst.
+// If the server supports Accept-Range, HttpGetter will attempt a range
+// request. This means it is the caller's responsibility to ensure that an
+// older version of the destination file does not exist, else it will be either
+// falsely identified as being replaced, or corrupted with extra bytes
+// appended.
 func (g *HttpGetter) GetFile(dst string, src *url.URL) error {
 	ctx := g.Context()
 	if g.Netrc {
@@ -139,7 +144,6 @@ func (g *HttpGetter) GetFile(dst string, src *url.URL) error {
 			return err
 		}
 	}
-
 	// Create all the parent directories if needed
 	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
 		return err
@@ -165,21 +169,20 @@ func (g *HttpGetter) GetFile(dst string, src *url.URL) error {
 		return err
 	}
 	if g.Header != nil {
-		req.Header = g.Header
+		req.Header = g.Header.Clone()
 	}
 	headResp, err := g.Client.Do(req)
-	if err == nil && headResp != nil {
+	if err == nil {
 		headResp.Body.Close()
 		if headResp.StatusCode == 200 {
 			// If the HEAD request succeeded, then attempt to set the range
 			// query if we can.
-			if headResp.Header.Get("Accept-Ranges") == "bytes" {
+			if headResp.Header.Get("Accept-Ranges") == "bytes" && headResp.ContentLength >= 0 {
 				if fi, err := f.Stat(); err == nil {
-					if _, err = f.Seek(0, os.SEEK_END); err == nil {
-						req.Header.Set("Range", fmt.Sprintf("bytes=%d-", fi.Size()))
+					if _, err = f.Seek(0, io.SeekEnd); err == nil {
 						currentFileSize = fi.Size()
-						totalFileSize, _ := strconv.ParseInt(headResp.Header.Get("Content-Length"), 10, 64)
-						if currentFileSize >= totalFileSize {
+						req.Header.Set("Range", fmt.Sprintf("bytes=%d-", currentFileSize))
+						if currentFileSize >= headResp.ContentLength {
 							// file already present
 							return nil
 						}


### PR DESCRIPTION
The range logic was being erroneously applied when there was no
Content-Length returned by the HEAD call. This frequently causes
download requests to report success without downloading anything, 
which results in the next process in the stream (the decompressor in 
the tar.gz case) to return an EOF error because there is no file content. 

Clone the http header when copying them to new requests, so that changes
are not inadvertently reflected in the caller.

The GetFile method still has the unfortunate behavior of not verifying
the destination file for the range request (which it currently can't,
because there is no metadata to compare). This means that a call to
replace an existing file when the server supports byte-range, will
either succeed if the new length is <= the previous, or corrupt the file
by appending new bytes. Silent corruption can be avoided by added a
`checksum` parameter to the go-getter request, but will still result in
failure to download.

Update the HttpGetter.GetFile method docs to reflect this behavior. In most
cases however the caller is not looking at the HttpGetter itself, as
go-getter is attempting to abstract this away. This means there needs to
be global support in the Client to make this a viable option. How to add
this can be decided separate from this fix.