### PR TITLE
make Get return GetResult

### DIFF
--- a/checksum.go
+++ b/checksum.go
@@ -211,7 +211,7 @@ func (c *Client) ChecksumFromFile(ctx context.Context, checksumURL, checksummedP
 		Dst: tempfile,
 		// ProgressListener: c.ProgressListener, TODO(adrien): pass progress bar ?
 	}
-	if err = c.Get(ctx, req); err != nil {
+	if _, err = c.Get(ctx, req); err != nil {
 		return nil, fmt.Errorf(
 			"Error downloading checksum file: %s", err)
 	}

--- a/client.go
+++ b/client.go
@@ -34,9 +34,9 @@ type Client struct {
 }
 
 // Get downloads the configured source to the destination.
-func (c *Client) Get(ctx context.Context, req *Request) error {
+func (c *Client) Get(ctx context.Context, req *Request) (*Operation, error) {
 	if err := c.configure(); err != nil {
-		return err
+		return nil, err
 	}
 
 	// Store this locally since there are cases we swap this
@@ -51,7 +51,7 @@ func (c *Client) Get(ctx context.Context, req *Request) error {
 	var err error
 	req.Src, err = Detect(req.Src, req.Pwd, c.Detectors)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var force string
@@ -65,7 +65,7 @@ func (c *Client) Get(ctx context.Context, req *Request) error {
 	if subDir != "" {
 		td, tdcloser, err := safetemp.Dir("", "getter")
 		if err != nil {
-			return err
+			return nil, err
 		}
 		defer tdcloser.Close()
 
@@ -75,7 +75,7 @@ func (c *Client) Get(ctx context.Context, req *Request) error {
 
 	req.u, err = urlhelper.Parse(req.Src)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if force == "" {
 		force = req.u.Scheme
@@ -83,7 +83,7 @@ func (c *Client) Get(ctx context.Context, req *Request) error {
 
 	g, ok := c.Getters[force]
 	if !ok {
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
 			"download not supported for scheme '%s'", force)
 	}
 
@@ -126,7 +126,7 @@ func (c *Client) Get(ctx context.Context, req *Request) error {
 		// this at the end of everything.
 		td, err := ioutil.TempDir("", "getter")
 		if err != nil {
-			return fmt.Errorf(
+			return nil, fmt.Errorf(
 				"Error creating temporary directory for archive: %s", err)
 		}
 		defer os.RemoveAll(td)
@@ -142,7 +142,7 @@ func (c *Client) Get(ctx context.Context, req *Request) error {
 	// Determine checksum if we have one
 	checksum, err := c.extractChecksum(ctx, req.u)
 	if err != nil {
-		return fmt.Errorf("invalid checksum: %s", err)
+		return nil, fmt.Errorf("invalid checksum: %s", err)
 	}
 
 	// Delete the query parameter if we have it.
@@ -153,7 +153,7 @@ func (c *Client) Get(ctx context.Context, req *Request) error {
 		// Ask the getter which client mode to use
 		req.Mode, err = g.ClientMode(ctx, req.u)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		// Destination is the base name of the URL path in "any" mode when
@@ -187,12 +187,12 @@ func (c *Client) Get(ctx context.Context, req *Request) error {
 		if getFile {
 			err := g.GetFile(ctx, req)
 			if err != nil {
-				return err
+				return nil, err
 			}
 
 			if checksum != nil {
 				if err := checksum.checksum(req.Dst); err != nil {
-					return err
+					return nil, err
 				}
 			}
 		}
@@ -202,7 +202,7 @@ func (c *Client) Get(ctx context.Context, req *Request) error {
 			// into the final destination with the proper mode.
 			err := decompressor.Decompress(decompressDst, req.Dst, decompressDir)
 			if err != nil {
-				return err
+				return nil, err
 			}
 
 			// Swap the information back
@@ -218,7 +218,7 @@ func (c *Client) Get(ctx context.Context, req *Request) error {
 		// if we were unarchiving. If we're still only Get-ing a file, then
 		// we're done.
 		if req.Mode == ClientModeFile {
-			return nil
+			return &Operation{req.Dst}, nil
 		}
 	}
 
@@ -230,7 +230,7 @@ func (c *Client) Get(ctx context.Context, req *Request) error {
 		// If we're getting a directory, then this is an error. You cannot
 		// checksum a directory. TODO: test
 		if checksum != nil {
-			return fmt.Errorf(
+			return nil, fmt.Errorf(
 				"checksum cannot be specified for directory download")
 		}
 
@@ -239,27 +239,27 @@ func (c *Client) Get(ctx context.Context, req *Request) error {
 		err := g.Get(ctx, req)
 		if err != nil {
 			err = fmt.Errorf("error downloading '%s': %s", req.Src, err)
-			return err
+			return nil, err
 		}
 	}
 
 	// If we have a subdir, copy that over
 	if subDir != "" {
 		if err := os.RemoveAll(realDst); err != nil {
-			return err
+			return nil, err
 		}
 		if err := os.MkdirAll(realDst, 0755); err != nil {
-			return err
+			return nil, err
 		}
 
 		// Process any globs
 		subDir, err := SubdirGlob(req.Dst, subDir)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
-		return copyDir(ctx, realDst, subDir, false)
+		return &Operation{realDst}, copyDir(ctx, realDst, subDir, false)
 	}
 
-	return nil
+	return &Operation{req.Dst}, nil
 }

--- a/client.go
+++ b/client.go
@@ -33,8 +33,14 @@ type Client struct {
 	Getters map[string]Getter
 }
 
+// GetResult is the result of a Client.Get
+type GetResult struct {
+	// Local destination of the gotten object.
+	Dst string
+}
+
 // Get downloads the configured source to the destination.
-func (c *Client) Get(ctx context.Context, req *Request) (*Operation, error) {
+func (c *Client) Get(ctx context.Context, req *Request) (*GetResult, error) {
 	if err := c.configure(); err != nil {
 		return nil, err
 	}
@@ -218,7 +224,7 @@ func (c *Client) Get(ctx context.Context, req *Request) (*Operation, error) {
 		// if we were unarchiving. If we're still only Get-ing a file, then
 		// we're done.
 		if req.Mode == ClientModeFile {
-			return &Operation{req.Dst}, nil
+			return &GetResult{req.Dst}, nil
 		}
 	}
 
@@ -258,8 +264,8 @@ func (c *Client) Get(ctx context.Context, req *Request) (*Operation, error) {
 			return nil, err
 		}
 
-		return &Operation{realDst}, copyDir(ctx, realDst, subDir, false)
+		return &GetResult{realDst}, copyDir(ctx, realDst, subDir, false)
 	}
 
-	return &Operation{req.Dst}, nil
+	return &GetResult{req.Dst}, nil
 }

--- a/client_option_progress_test.go
+++ b/client_option_progress_test.go
@@ -41,7 +41,7 @@ func TestGet_progress(t *testing.T) {
 	{ // dl without tracking
 		dst := tempTestFile(t)
 		defer os.RemoveAll(filepath.Dir(dst))
-		if err := GetFile(ctx, dst, s.URL+"/file?thig=this&that"); err != nil {
+		if _, err := GetFile(ctx, dst, s.URL+"/file?thig=this&that"); err != nil {
 			t.Fatalf("download failed: %v", err)
 		}
 	}
@@ -56,7 +56,7 @@ func TestGet_progress(t *testing.T) {
 			ProgressListener: p,
 			Dir:              false,
 		}
-		if err := DefaultClient.Get(ctx, req); err != nil {
+		if _, err := DefaultClient.Get(ctx, req); err != nil {
 			t.Fatalf("download failed: %v", err)
 		}
 		req = &Request{
@@ -65,7 +65,7 @@ func TestGet_progress(t *testing.T) {
 			ProgressListener: p,
 			Dir:              false,
 		}
-		if err := DefaultClient.Get(ctx, req); err != nil {
+		if _, err := DefaultClient.Get(ctx, req); err != nil {
 			t.Fatalf("download failed: %v", err)
 		}
 

--- a/cmd/go-getter/main.go
+++ b/cmd/go-getter/main.go
@@ -55,13 +55,17 @@ func main() {
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)
+
 	errChan := make(chan error, 2)
 	go func() {
 		defer wg.Done()
 		defer cancel()
-		if err := getter.DefaultClient.Get(ctx, req); err != nil {
+		res, err := getter.DefaultClient.Get(ctx, req)
+		if err != nil {
 			errChan <- err
+			return
 		}
+		log.Printf("-> %s", res.Dst)
 	}()
 
 	c := make(chan os.Signal)
@@ -75,7 +79,6 @@ func main() {
 		log.Printf("signal %v", sig)
 	case <-ctx.Done():
 		wg.Wait()
-		log.Printf("success!")
 	case err := <-errChan:
 		wg.Wait()
 		log.Fatalf("Error downloading: %s", err)

--- a/folder_storage.go
+++ b/folder_storage.go
@@ -55,7 +55,8 @@ func (s *FolderStorage) Get(ctx context.Context, key string, source string, upda
 	}
 
 	// Get the source. This always forces an update.
-	return Get(ctx, dir, source)
+	_, err := Get(ctx, dir, source)
+	return err
 }
 
 // dir returns the directory name internally that we'll use to map to

--- a/get.go
+++ b/get.go
@@ -87,7 +87,7 @@ func init() {
 //
 // src is a URL, whereas dst is always just a file path to a folder. This
 // folder doesn't need to exist. It will be created if it doesn't exist.
-func Get(ctx context.Context, dst, src string) error {
+func Get(ctx context.Context, dst, src string) (*Operation, error) {
 	req := &Request{
 		Src: src,
 		Dst: dst,
@@ -102,7 +102,7 @@ func Get(ctx context.Context, dst, src string) error {
 // dst must be a directory. If src is a file, it will be downloaded
 // into dst with the basename of the URL. If src is a directory or
 // archive, it will be unpacked directly into dst.
-func GetAny(ctx context.Context, dst, src string) error {
+func GetAny(ctx context.Context, dst, src string) (*Operation, error) {
 	req := &Request{
 		Src:  src,
 		Dst:  dst,
@@ -113,7 +113,7 @@ func GetAny(ctx context.Context, dst, src string) error {
 
 // GetFile downloads the file specified by src into the path specified by
 // dst.
-func GetFile(ctx context.Context, dst, src string) error {
+func GetFile(ctx context.Context, dst, src string) (*Operation, error) {
 	req := &Request{
 		Src: src,
 		Dst: dst,

--- a/get.go
+++ b/get.go
@@ -87,7 +87,7 @@ func init() {
 //
 // src is a URL, whereas dst is always just a file path to a folder. This
 // folder doesn't need to exist. It will be created if it doesn't exist.
-func Get(ctx context.Context, dst, src string) (*Operation, error) {
+func Get(ctx context.Context, dst, src string) (*GetResult, error) {
 	req := &Request{
 		Src: src,
 		Dst: dst,
@@ -102,7 +102,7 @@ func Get(ctx context.Context, dst, src string) (*Operation, error) {
 // dst must be a directory. If src is a file, it will be downloaded
 // into dst with the basename of the URL. If src is a directory or
 // archive, it will be unpacked directly into dst.
-func GetAny(ctx context.Context, dst, src string) (*Operation, error) {
+func GetAny(ctx context.Context, dst, src string) (*GetResult, error) {
 	req := &Request{
 		Src:  src,
 		Dst:  dst,
@@ -113,7 +113,7 @@ func GetAny(ctx context.Context, dst, src string) (*Operation, error) {
 
 // GetFile downloads the file specified by src into the path specified by
 // dst.
-func GetFile(ctx context.Context, dst, src string) (*Operation, error) {
+func GetFile(ctx context.Context, dst, src string) (*GetResult, error) {
 	req := &Request{
 		Src: src,
 		Dst: dst,

--- a/get_git_test.go
+++ b/get_git_test.go
@@ -420,7 +420,7 @@ func TestGitGetter_sshSCPStyle(t *testing.T) {
 		},
 	}
 
-	if err := client.Get(ctx, req); err != nil {
+	if _, err := client.Get(ctx, req); err != nil {
 		t.Fatalf("client.Get failed: %s", err)
 	}
 
@@ -464,7 +464,7 @@ func TestGitGetter_sshExplicitPort(t *testing.T) {
 		},
 	}
 
-	if err := client.Get(ctx, req); err != nil {
+	if _, err := client.Get(ctx, req); err != nil {
 		t.Fatalf("client.Get failed: %s", err)
 	}
 
@@ -508,7 +508,7 @@ func TestGitGetter_sshSCPStyleInvalidScheme(t *testing.T) {
 		},
 	}
 
-	err := client.Get(ctx, req)
+	_, err := client.Get(ctx, req)
 	if err == nil {
 		t.Fatalf("get succeeded; want error")
 	}

--- a/get_http.go
+++ b/get_http.go
@@ -122,7 +122,8 @@ func (g *HttpGetter) Get(ctx context.Context, req *Request) error {
 		Dst: req.Dst,
 	}
 	if subDir == "" {
-		return DefaultClient.Get(ctx, req)
+		_, err = DefaultClient.Get(ctx, req)
+		return err
 	}
 	// We have a subdir, time to jump some hoops
 	return g.getSubdir(ctx, req.Dst, source, subDir)
@@ -230,7 +231,7 @@ func (g *HttpGetter) getSubdir(ctx context.Context, dst, source, subDir string) 
 	defer tdcloser.Close()
 
 	// Download that into the given directory
-	if err := Get(ctx, td, source); err != nil {
+	if _, err := Get(ctx, td, source); err != nil {
 		return err
 	}
 

--- a/get_http_test.go
+++ b/get_http_test.go
@@ -298,7 +298,7 @@ func TestHttpGetter_resumeNoRange(t *testing.T) {
 	ctx := context.Background()
 
 	// Finish getting it!
-	if err := GetFile(ctx, dst, u.String()); err != nil {
+	if _, err := GetFile(ctx, dst, u.String()); err != nil {
 		t.Fatalf("finishing download should not error: %v", err)
 	}
 

--- a/get_http_test.go
+++ b/get_http_test.go
@@ -241,7 +241,7 @@ func TestHttpGetter_resume(t *testing.T) {
 	ctx := context.Background()
 
 	// Finish getting it!
-	if err := GetFile(ctx, dst, u.String()); err != nil {
+	if _, err := GetFile(ctx, dst, u.String()); err != nil {
 		t.Fatalf("finishing download should not error: %v", err)
 	}
 
@@ -255,7 +255,7 @@ func TestHttpGetter_resume(t *testing.T) {
 	}
 
 	// Get it again
-	if err := GetFile(ctx, dst, u.String()); err != nil {
+	if _, err := GetFile(ctx, dst, u.String()); err != nil {
 		t.Fatalf("should not error: %v", err)
 	}
 }

--- a/get_test.go
+++ b/get_test.go
@@ -15,7 +15,7 @@ func TestGet_badSchema(t *testing.T) {
 	u := testModule("basic")
 	u = strings.Replace(u, "file", "nope", -1)
 
-	if err := Get(ctx, dst, u); err == nil {
+	if _, err := Get(ctx, dst, u); err == nil {
 		t.Fatal("should error")
 	}
 }
@@ -26,7 +26,7 @@ func TestGet_file(t *testing.T) {
 	dst := tempDir(t)
 	u := testModule("basic")
 
-	if err := Get(ctx, dst, u); err != nil {
+	if _, err := Get(ctx, dst, u); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -43,7 +43,7 @@ func TestGet_fileDecompressorExt(t *testing.T) {
 	dst := tempDir(t)
 	u := testModule("basic-tgz")
 
-	if err := Get(ctx, dst, u); err != nil {
+	if _, err := Get(ctx, dst, u); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -60,7 +60,7 @@ func TestGet_filePercent2F(t *testing.T) {
 	dst := tempDir(t)
 	u := testModule("basic%2Ftest")
 
-	if err := Get(ctx, dst, u); err != nil {
+	if _, err := Get(ctx, dst, u); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -92,7 +92,7 @@ func TestGet_fileDetect(t *testing.T) {
 		t.Fatalf("configure: %s", err)
 	}
 
-	if err := client.Get(ctx, req); err != nil {
+	if _, err := client.Get(ctx, req); err != nil {
 		t.Fatalf("get: %s", err)
 	}
 
@@ -109,7 +109,7 @@ func TestGet_fileForced(t *testing.T) {
 	u := testModule("basic")
 	u = "file::" + u
 
-	if err := Get(ctx, dst, u); err != nil {
+	if _, err := Get(ctx, dst, u); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -125,7 +125,7 @@ func TestGet_fileSubdir(t *testing.T) {
 	dst := tempDir(t)
 	u := testModule("basic//subdir")
 
-	if err := Get(ctx, dst, u); err != nil {
+	if _, err := Get(ctx, dst, u); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -142,7 +142,7 @@ func TestGet_archive(t *testing.T) {
 	u := filepath.Join("./testdata", "archive.tar.gz")
 	u, _ = filepath.Abs(u)
 
-	if err := Get(ctx, dst, u); err != nil {
+	if _, err := Get(ctx, dst, u); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -159,7 +159,7 @@ func TestGetAny_archive(t *testing.T) {
 	u := filepath.Join("./testdata", "archive.tar.gz")
 	u, _ = filepath.Abs(u)
 
-	if err := GetAny(ctx, dst, u); err != nil {
+	if _, err := GetAny(ctx, dst, u); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -174,7 +174,7 @@ func TestGet_archiveRooted(t *testing.T) {
 
 	dst := tempDir(t)
 	u := testModule("archive-rooted/archive.tar.gz")
-	if err := Get(ctx, dst, u); err != nil {
+	if _, err := Get(ctx, dst, u); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -190,7 +190,7 @@ func TestGet_archiveSubdirWild(t *testing.T) {
 	dst := tempDir(t)
 	u := testModule("archive-rooted/archive.tar.gz")
 	u += "//*"
-	if err := Get(ctx, dst, u); err != nil {
+	if _, err := Get(ctx, dst, u); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -206,7 +206,7 @@ func TestGet_archiveSubdirWildMultiMatch(t *testing.T) {
 	dst := tempDir(t)
 	u := testModule("archive-rooted-multi/archive.tar.gz")
 	u += "//*"
-	if err := Get(ctx, dst, u); err == nil {
+	if _, err := Get(ctx, dst, u); err == nil {
 		t.Fatal("should error")
 	} else if !strings.Contains(err.Error(), "multiple") {
 		t.Fatalf("err: %s", err)
@@ -219,7 +219,7 @@ func TestGetAny_file(t *testing.T) {
 	dst := tempDir(t)
 	u := testModule("basic-file/foo.txt")
 
-	if err := GetAny(ctx, dst, u); err != nil {
+	if _, err := GetAny(ctx, dst, u); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -236,7 +236,7 @@ func TestGetAny_dir(t *testing.T) {
 	u := filepath.Join("./testdata", "basic")
 	u, _ = filepath.Abs(u)
 
-	if err := GetAny(ctx, dst, u); err != nil {
+	if _, err := GetAny(ctx, dst, u); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -260,7 +260,7 @@ func TestGetFile(t *testing.T) {
 	defer os.RemoveAll(filepath.Dir(dst))
 	u := testModule("basic-file/foo.txt")
 
-	if err := GetFile(ctx, dst, u); err != nil {
+	if _, err := GetFile(ctx, dst, u); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -275,7 +275,7 @@ func TestGetFile_archive(t *testing.T) {
 	defer os.RemoveAll(filepath.Dir(dst))
 	u := testModule("basic-file-archive/archive.tar.gz")
 
-	if err := GetFile(ctx, dst, u); err != nil {
+	if _, err := GetFile(ctx, dst, u); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -291,7 +291,7 @@ func TestGetFile_archiveChecksum(t *testing.T) {
 	u := testModule(
 		"basic-file-archive/archive.tar.gz?checksum=md5:fbd90037dacc4b1ab40811d610dde2f0")
 
-	if err := GetFile(ctx, dst, u); err != nil {
+	if _, err := GetFile(ctx, dst, u); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -307,7 +307,7 @@ func TestGetFile_archiveNoUnarchive(t *testing.T) {
 	u := testModule("basic-file-archive/archive.tar.gz")
 	u += "?archive=false"
 
-	if err := GetFile(ctx, dst, u); err != nil {
+	if _, err := GetFile(ctx, dst, u); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -394,7 +394,7 @@ func TestGetFile_checksum(t *testing.T) {
 		func() {
 			dst := tempTestFile(t)
 			defer os.RemoveAll(filepath.Dir(dst))
-			if err := GetFile(ctx, dst, u); (err != nil) != tc.Err {
+			if _, err := GetFile(ctx, dst, u); (err != nil) != tc.Err {
 				t.Fatalf("append: %s\n\nerr: %s", tc.Append, err)
 			}
 
@@ -477,7 +477,7 @@ func TestGetFile_checksum_from_file(t *testing.T) {
 
 			dst := tempTestFile(t)
 			defer os.RemoveAll(filepath.Dir(dst))
-			if err := GetFile(ctx, dst, u); (err != nil) != tc.WantErr {
+			if _, err := GetFile(ctx, dst, u); (err != nil) != tc.WantErr {
 				t.Fatalf("append: %s\n\nerr: %s", tc.Append, err)
 			}
 
@@ -508,7 +508,7 @@ func TestGetFile_checksumURL(t *testing.T) {
 		},
 	}
 
-	if err := client.Get(ctx, req); err != nil {
+	if _, err := client.Get(ctx, req); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -525,7 +525,7 @@ func TestGetFile_filename(t *testing.T) {
 
 	u += "?filename=bar.txt"
 
-	if err := GetAny(ctx, dst, u); err != nil {
+	if _, err := GetAny(ctx, dst, u); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -555,7 +555,7 @@ func TestGetFile_checksumSkip(t *testing.T) {
 	}
 
 	// get the file
-	if err := client.Get(ctx, req); err != nil {
+	if _, err := client.Get(ctx, req); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -567,7 +567,7 @@ func TestGetFile_checksumSkip(t *testing.T) {
 	getter.Proxy = nil
 	getter.GetFileCalled = false
 
-	if err := client.Get(ctx, req); err != nil {
+	if _, err := client.Get(ctx, req); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 

--- a/get_test.go
+++ b/get_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestGet_badSchema(t *testing.T) {
@@ -15,8 +17,12 @@ func TestGet_badSchema(t *testing.T) {
 	u := testModule("basic")
 	u = strings.Replace(u, "file", "nope", -1)
 
-	if _, err := Get(ctx, dst, u); err == nil {
+	op, err := Get(ctx, dst, u)
+	if err == nil {
 		t.Fatal("should error")
+	}
+	if op != nil {
+		t.Fatal("op should be nil")
 	}
 }
 
@@ -26,8 +32,12 @@ func TestGet_file(t *testing.T) {
 	dst := tempDir(t)
 	u := testModule("basic")
 
-	if _, err := Get(ctx, dst, u); err != nil {
+	op, err := Get(ctx, dst, u)
+	if err != nil {
 		t.Fatalf("err: %s", err)
+	}
+	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+		t.Fatalf("unexpected op: %s", diff)
 	}
 
 	mainPath := filepath.Join(dst, "main.tf")
@@ -43,8 +53,12 @@ func TestGet_fileDecompressorExt(t *testing.T) {
 	dst := tempDir(t)
 	u := testModule("basic-tgz")
 
-	if _, err := Get(ctx, dst, u); err != nil {
+	op, err := Get(ctx, dst, u)
+	if err != nil {
 		t.Fatalf("err: %s", err)
+	}
+	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+		t.Fatalf("unexpected op: %s", diff)
 	}
 
 	mainPath := filepath.Join(dst, "main.tf")
@@ -60,8 +74,12 @@ func TestGet_filePercent2F(t *testing.T) {
 	dst := tempDir(t)
 	u := testModule("basic%2Ftest")
 
-	if _, err := Get(ctx, dst, u); err != nil {
+	op, err := Get(ctx, dst, u)
+	if err != nil {
 		t.Fatalf("err: %s", err)
+	}
+	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+		t.Fatalf("unexpected op: %s", diff)
 	}
 
 	mainPath := filepath.Join(dst, "main.tf")
@@ -92,8 +110,12 @@ func TestGet_fileDetect(t *testing.T) {
 		t.Fatalf("configure: %s", err)
 	}
 
-	if _, err := client.Get(ctx, req); err != nil {
+	op, err := client.Get(ctx, req)
+	if err != nil {
 		t.Fatalf("get: %s", err)
+	}
+	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+		t.Fatalf("unexpected op: %s", diff)
 	}
 
 	mainPath := filepath.Join(dst, "main.tf")
@@ -109,8 +131,12 @@ func TestGet_fileForced(t *testing.T) {
 	u := testModule("basic")
 	u = "file::" + u
 
-	if _, err := Get(ctx, dst, u); err != nil {
+	op, err := Get(ctx, dst, u)
+	if err != nil {
 		t.Fatalf("err: %s", err)
+	}
+	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+		t.Fatalf("unexpected op: %s", diff)
 	}
 
 	mainPath := filepath.Join(dst, "main.tf")
@@ -125,8 +151,12 @@ func TestGet_fileSubdir(t *testing.T) {
 	dst := tempDir(t)
 	u := testModule("basic//subdir")
 
-	if _, err := Get(ctx, dst, u); err != nil {
+	op, err := Get(ctx, dst, u)
+	if err != nil {
 		t.Fatalf("err: %s", err)
+	}
+	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+		t.Fatalf("unexpected op: %s", diff)
 	}
 
 	mainPath := filepath.Join(dst, "sub.tf")
@@ -142,8 +172,12 @@ func TestGet_archive(t *testing.T) {
 	u := filepath.Join("./testdata", "archive.tar.gz")
 	u, _ = filepath.Abs(u)
 
-	if _, err := Get(ctx, dst, u); err != nil {
+	op, err := Get(ctx, dst, u)
+	if err != nil {
 		t.Fatalf("err: %s", err)
+	}
+	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+		t.Fatalf("unexpected op: %s", diff)
 	}
 
 	mainPath := filepath.Join(dst, "main.tf")
@@ -159,8 +193,12 @@ func TestGetAny_archive(t *testing.T) {
 	u := filepath.Join("./testdata", "archive.tar.gz")
 	u, _ = filepath.Abs(u)
 
-	if _, err := GetAny(ctx, dst, u); err != nil {
+	op, err := GetAny(ctx, dst, u)
+	if err != nil {
 		t.Fatalf("err: %s", err)
+	}
+	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+		t.Fatalf("unexpected op: %s", diff)
 	}
 
 	mainPath := filepath.Join(dst, "main.tf")
@@ -174,8 +212,12 @@ func TestGet_archiveRooted(t *testing.T) {
 
 	dst := tempDir(t)
 	u := testModule("archive-rooted/archive.tar.gz")
-	if _, err := Get(ctx, dst, u); err != nil {
+	op, err := Get(ctx, dst, u)
+	if err != nil {
 		t.Fatalf("err: %s", err)
+	}
+	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+		t.Fatalf("unexpected op: %s", diff)
 	}
 
 	mainPath := filepath.Join(dst, "root", "hello.txt")
@@ -190,8 +232,12 @@ func TestGet_archiveSubdirWild(t *testing.T) {
 	dst := tempDir(t)
 	u := testModule("archive-rooted/archive.tar.gz")
 	u += "//*"
-	if _, err := Get(ctx, dst, u); err != nil {
+	op, err := Get(ctx, dst, u)
+	if err != nil {
 		t.Fatalf("err: %s", err)
+	}
+	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+		t.Fatalf("unexpected op: %s", diff)
 	}
 
 	mainPath := filepath.Join(dst, "hello.txt")
@@ -206,10 +252,17 @@ func TestGet_archiveSubdirWildMultiMatch(t *testing.T) {
 	dst := tempDir(t)
 	u := testModule("archive-rooted-multi/archive.tar.gz")
 	u += "//*"
-	if _, err := Get(ctx, dst, u); err == nil {
+	op, err := Get(ctx, dst, u)
+	switch err {
+	case nil:
 		t.Fatal("should error")
-	} else if !strings.Contains(err.Error(), "multiple") {
-		t.Fatalf("err: %s", err)
+	default:
+		if !strings.Contains(err.Error(), "multiple") {
+			t.Fatalf("err: %s", err)
+		}
+		if op != nil {
+			t.Fatal("operation should be nil")
+		}
 	}
 }
 
@@ -236,8 +289,12 @@ func TestGetAny_dir(t *testing.T) {
 	u := filepath.Join("./testdata", "basic")
 	u, _ = filepath.Abs(u)
 
-	if _, err := GetAny(ctx, dst, u); err != nil {
+	op, err := GetAny(ctx, dst, u)
+	if err != nil {
 		t.Fatalf("err: %s", err)
+	}
+	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+		t.Fatalf("unexpected op: %s", diff)
 	}
 
 	check := []string{
@@ -260,8 +317,12 @@ func TestGetFile(t *testing.T) {
 	defer os.RemoveAll(filepath.Dir(dst))
 	u := testModule("basic-file/foo.txt")
 
-	if _, err := GetFile(ctx, dst, u); err != nil {
+	op, err := GetFile(ctx, dst, u)
+	if err != nil {
 		t.Fatalf("err: %s", err)
+	}
+	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+		t.Fatalf("unexpected op: %s", diff)
 	}
 
 	// Verify the main file exists
@@ -275,8 +336,12 @@ func TestGetFile_archive(t *testing.T) {
 	defer os.RemoveAll(filepath.Dir(dst))
 	u := testModule("basic-file-archive/archive.tar.gz")
 
-	if _, err := GetFile(ctx, dst, u); err != nil {
+	op, err := GetFile(ctx, dst, u)
+	if err != nil {
 		t.Fatalf("err: %s", err)
+	}
+	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+		t.Fatalf("unexpected op: %s", diff)
 	}
 
 	// Verify the main file exists
@@ -291,8 +356,12 @@ func TestGetFile_archiveChecksum(t *testing.T) {
 	u := testModule(
 		"basic-file-archive/archive.tar.gz?checksum=md5:fbd90037dacc4b1ab40811d610dde2f0")
 
-	if _, err := GetFile(ctx, dst, u); err != nil {
+	op, err := GetFile(ctx, dst, u)
+	if err != nil {
 		t.Fatalf("err: %s", err)
+	}
+	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+		t.Fatalf("unexpected op: %s", diff)
 	}
 
 	// Verify the main file exists
@@ -307,8 +376,12 @@ func TestGetFile_archiveNoUnarchive(t *testing.T) {
 	u := testModule("basic-file-archive/archive.tar.gz")
 	u += "?archive=false"
 
-	if _, err := GetFile(ctx, dst, u); err != nil {
+	op, err := GetFile(ctx, dst, u)
+	if err != nil {
 		t.Fatalf("err: %s", err)
+	}
+	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+		t.Fatalf("unexpected op: %s", diff)
 	}
 
 	// Verify the main file exists
@@ -394,8 +467,14 @@ func TestGetFile_checksum(t *testing.T) {
 		func() {
 			dst := tempTestFile(t)
 			defer os.RemoveAll(filepath.Dir(dst))
-			if _, err := GetFile(ctx, dst, u); (err != nil) != tc.Err {
+			op, err := GetFile(ctx, dst, u)
+			if (err != nil) != tc.Err {
 				t.Fatalf("append: %s\n\nerr: %s", tc.Append, err)
+			}
+			if err == nil {
+				if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+					t.Fatalf("unexpected dst: %s", diff)
+				}
 			}
 
 			// Verify the main file exists
@@ -477,8 +556,14 @@ func TestGetFile_checksum_from_file(t *testing.T) {
 
 			dst := tempTestFile(t)
 			defer os.RemoveAll(filepath.Dir(dst))
-			if _, err := GetFile(ctx, dst, u); (err != nil) != tc.WantErr {
+			op, err := GetFile(ctx, dst, u)
+			if (err != nil) != tc.WantErr {
 				t.Fatalf("append: %s\n\nerr: %s", tc.Append, err)
+			}
+			if err == nil {
+				if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+					t.Fatalf("unexpected dst: %s", diff)
+				}
 			}
 
 			if tc.WantTransfer {
@@ -508,8 +593,12 @@ func TestGetFile_checksumURL(t *testing.T) {
 		},
 	}
 
-	if _, err := client.Get(ctx, req); err != nil {
+	op, err := client.Get(ctx, req)
+	if err != nil {
 		t.Fatalf("err: %s", err)
+	}
+	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+		t.Fatalf("unexpected op: %s", diff)
 	}
 
 	if v := getter.GetFileURL.Query().Get("checksum"); v != "" {
@@ -524,12 +613,17 @@ func TestGetFile_filename(t *testing.T) {
 	u := testModule("basic-file/foo.txt")
 
 	u += "?filename=bar.txt"
+	realDst := filepath.Join(dst, "bar.txt")
 
-	if _, err := GetAny(ctx, dst, u); err != nil {
+	op, err := GetAny(ctx, dst, u)
+	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
+	if diff := cmp.Diff(realDst, op.Dst); diff != "" {
+		t.Fatalf("unexpected op: %s", diff)
+	}
 
-	mainPath := filepath.Join(dst, "bar.txt")
+	mainPath := realDst
 	if _, err := os.Stat(mainPath); err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -555,8 +649,12 @@ func TestGetFile_checksumSkip(t *testing.T) {
 	}
 
 	// get the file
-	if _, err := client.Get(ctx, req); err != nil {
+	op, err := client.Get(ctx, req)
+	if err != nil {
 		t.Fatalf("err: %s", err)
+	}
+	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+		t.Fatalf("unexpected op: %s", diff)
 	}
 
 	if v := getter.GetFileURL.Query().Get("checksum"); v != "" {
@@ -567,8 +665,12 @@ func TestGetFile_checksumSkip(t *testing.T) {
 	getter.Proxy = nil
 	getter.GetFileCalled = false
 
-	if _, err := client.Get(ctx, req); err != nil {
+	op, err = client.Get(ctx, req)
+	if err != nil {
 		t.Fatalf("err: %s", err)
+	}
+	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+		t.Fatalf("unexpected op: %s", diff)
 	}
 
 	if getter.GetFileCalled {

--- a/get_test.go
+++ b/get_test.go
@@ -36,7 +36,7 @@ func TestGet_file(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+	if diff := cmp.Diff(&GetResult{Dst: dst}, op); diff != "" {
 		t.Fatalf("unexpected op: %s", diff)
 	}
 
@@ -57,7 +57,7 @@ func TestGet_fileDecompressorExt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+	if diff := cmp.Diff(&GetResult{Dst: dst}, op); diff != "" {
 		t.Fatalf("unexpected op: %s", diff)
 	}
 
@@ -78,7 +78,7 @@ func TestGet_filePercent2F(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+	if diff := cmp.Diff(&GetResult{Dst: dst}, op); diff != "" {
 		t.Fatalf("unexpected op: %s", diff)
 	}
 
@@ -114,7 +114,7 @@ func TestGet_fileDetect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get: %s", err)
 	}
-	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+	if diff := cmp.Diff(&GetResult{Dst: dst}, op); diff != "" {
 		t.Fatalf("unexpected op: %s", diff)
 	}
 
@@ -135,7 +135,7 @@ func TestGet_fileForced(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+	if diff := cmp.Diff(&GetResult{Dst: dst}, op); diff != "" {
 		t.Fatalf("unexpected op: %s", diff)
 	}
 
@@ -155,7 +155,7 @@ func TestGet_fileSubdir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+	if diff := cmp.Diff(&GetResult{Dst: dst}, op); diff != "" {
 		t.Fatalf("unexpected op: %s", diff)
 	}
 
@@ -176,7 +176,7 @@ func TestGet_archive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+	if diff := cmp.Diff(&GetResult{Dst: dst}, op); diff != "" {
 		t.Fatalf("unexpected op: %s", diff)
 	}
 
@@ -197,7 +197,7 @@ func TestGetAny_archive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+	if diff := cmp.Diff(&GetResult{Dst: dst}, op); diff != "" {
 		t.Fatalf("unexpected op: %s", diff)
 	}
 
@@ -216,7 +216,7 @@ func TestGet_archiveRooted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+	if diff := cmp.Diff(&GetResult{Dst: dst}, op); diff != "" {
 		t.Fatalf("unexpected op: %s", diff)
 	}
 
@@ -236,7 +236,7 @@ func TestGet_archiveSubdirWild(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+	if diff := cmp.Diff(&GetResult{Dst: dst}, op); diff != "" {
 		t.Fatalf("unexpected op: %s", diff)
 	}
 
@@ -293,7 +293,7 @@ func TestGetAny_dir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+	if diff := cmp.Diff(&GetResult{Dst: dst}, op); diff != "" {
 		t.Fatalf("unexpected op: %s", diff)
 	}
 
@@ -321,7 +321,7 @@ func TestGetFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+	if diff := cmp.Diff(&GetResult{Dst: dst}, op); diff != "" {
 		t.Fatalf("unexpected op: %s", diff)
 	}
 
@@ -340,7 +340,7 @@ func TestGetFile_archive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+	if diff := cmp.Diff(&GetResult{Dst: dst}, op); diff != "" {
 		t.Fatalf("unexpected op: %s", diff)
 	}
 
@@ -360,7 +360,7 @@ func TestGetFile_archiveChecksum(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+	if diff := cmp.Diff(&GetResult{Dst: dst}, op); diff != "" {
 		t.Fatalf("unexpected op: %s", diff)
 	}
 
@@ -380,7 +380,7 @@ func TestGetFile_archiveNoUnarchive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+	if diff := cmp.Diff(&GetResult{Dst: dst}, op); diff != "" {
 		t.Fatalf("unexpected op: %s", diff)
 	}
 
@@ -472,7 +472,7 @@ func TestGetFile_checksum(t *testing.T) {
 				t.Fatalf("append: %s\n\nerr: %s", tc.Append, err)
 			}
 			if err == nil {
-				if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+				if diff := cmp.Diff(&GetResult{Dst: dst}, op); diff != "" {
 					t.Fatalf("unexpected dst: %s", diff)
 				}
 			}
@@ -561,7 +561,7 @@ func TestGetFile_checksum_from_file(t *testing.T) {
 				t.Fatalf("append: %s\n\nerr: %s", tc.Append, err)
 			}
 			if err == nil {
-				if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+				if diff := cmp.Diff(&GetResult{Dst: dst}, op); diff != "" {
 					t.Fatalf("unexpected dst: %s", diff)
 				}
 			}
@@ -597,7 +597,7 @@ func TestGetFile_checksumURL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+	if diff := cmp.Diff(&GetResult{Dst: dst}, op); diff != "" {
 		t.Fatalf("unexpected op: %s", diff)
 	}
 
@@ -653,7 +653,7 @@ func TestGetFile_checksumSkip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+	if diff := cmp.Diff(&GetResult{Dst: dst}, op); diff != "" {
 		t.Fatalf("unexpected op: %s", diff)
 	}
 
@@ -669,7 +669,7 @@ func TestGetFile_checksumSkip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if diff := cmp.Diff(&Operation{Dst: dst}, op); diff != "" {
+	if diff := cmp.Diff(&GetResult{Dst: dst}, op); diff != "" {
 		t.Fatalf("unexpected op: %s", diff)
 	}
 

--- a/operation.go
+++ b/operation.go
@@ -1,0 +1,7 @@
+package getter
+
+// Operation is the result of a get
+type Operation struct {
+	// Local destination of the gotten object.
+	Dst string
+}

--- a/operation.go
+++ b/operation.go
@@ -1,7 +1,0 @@
-package getter
-
-// Operation is the result of a get
-type Operation struct {
-	// Local destination of the gotten object.
-	Dst string
-}


### PR DESCRIPTION
This pr is based upon #230, merging it will close #230; but I split them in order to allow to review the changes in smaller contextualised chunks. ( which I recommend )

The features of this PR allow to tell what operation was done by the go getter; this will allow the go-getter to 'make a choice' based on a set of arguments.

For example:
* Decide of a random temporary folder/file in which to put the wanted object and then tell us where it was put.
* just tell that this file was not being copied but simply referenced because it is already in the drive ( this one is usefull to Packer )

This PR is reopening #177 but to merge it on the `v2` branch.