### PR TITLE
Pin Go to 1.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,3 +21,5 @@ require (
 	google.golang.org/api v0.9.0
 	gopkg.in/cheggaaa/pb.v1 v1.0.27 // indirect
 )
+
+go 1.13


### PR DESCRIPTION
https://github.com/hashicorp/go-getter/pull/227 made consumers of go-getter require Go 1.13 due to [`Clone` methods](https://golang.org/pkg/net/http/#Header.Clone) that are only available in 1.13, so this hint should help consumers realize that.

### Before

```
$ go get github.com/hashicorp/go-getter@v1.4.1
# github.com/hashicorp/go-getter
../../../../../go/1.12.9/pkg/mod/github.com/hashicorp/go-getter@v1.4.1/get_http.go:91:24: g.Header.Clone undefined (type http.Header has no field or method Clone)
../../../../../go/1.12.9/pkg/mod/github.com/hashicorp/go-getter@v1.4.1/get_http.go:172:24: g.Header.Clone undefined (type http.Header has no field or method Clone)
```

### After

```
$ go get github.com/hashicorp/go-getter@52561d917139cde51332028978627cd2f8b42d6c
# github.com/hashicorp/go-getter
../../../../../go/1.12.9/pkg/mod/github.com/hashicorp/go-getter@v1.4.2-0.20200204132553-52561d917139/get_http.go:91:24: g.Header.Clone undefined (type http.Header has no field or method Clone)
../../../../../go/1.12.9/pkg/mod/github.com/hashicorp/go-getter@v1.4.2-0.20200204132553-52561d917139/get_http.go:172:24: g.Header.Clone undefined (type http.Header has no field or method Clone)
note: module requires Go 1.13
```