### PR TITLE
Skip any netrc files that are inaccessible

### DIFF
--- a/netrc.go
+++ b/netrc.go
@@ -11,9 +11,9 @@ import (
 )
 
 // addAuthFromNetrc adds auth information to the URL from the user's
-// netrc file if it can be found. This will only add the auth info
-// if the URL doesn't already have auth info specified and the
-// the username is blank.
+// netrc file if it can be found and read. This will only add the
+// auth info if the URL doesn't already have auth info specified
+// and the the username is blank.
 func addAuthFromNetrc(u *url.URL) error {
 	// If the URL already has auth information, do nothing
 	if u.User != nil && u.User.Username() != "" {
@@ -52,6 +52,11 @@ func addAuthFromNetrc(u *url.URL) error {
 	// Load up the netrc file
 	net, err := netrc.ParseFile(path)
 	if err != nil {
+		// File is inaccessible, do nothing
+		if os.IsPermission(err) {
+			return nil
+		}
+
 		return fmt.Errorf("Error parsing netrc file at %q: %s", path, err)
 	}
 

--- a/netrc_test.go
+++ b/netrc_test.go
@@ -2,6 +2,8 @@ package getter
 
 import (
 	"net/url"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -21,6 +23,31 @@ func TestAddAuthFromNetrc(t *testing.T) {
 	actual := u.String()
 	if expected != actual {
 		t.Fatalf("Mismatch: %q != %q", actual, expected)
+	}
+}
+
+func TestAddAuthFromNetrc_secret(t *testing.T) {
+	dir := tempDir(t)
+	if err := os.Mkdir(dir, 0755); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	netrc := filepath.Join(dir, ".netrc")
+	if _, err := os.Create(netrc); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if err := os.Chmod(netrc, 0000); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	defer tempEnv(t, "NETRC", netrc)()
+	defer os.RemoveAll(dir)
+
+	u, err := url.Parse("http://example.com")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if err := addAuthFromNetrc(u); err != nil {
+		t.Fatalf("err: %s", err)
 	}
 }
 


### PR DESCRIPTION
Some people keep unreadable .netrc files in their home directory...
Ignore parsing these files, instead of throwing "permission denied".

This matches the behaviour of e.g. `curl`, and saves users from
having to set NETRC when they actually want to avoid such a file.

Closes #221