### PR TITLE
Create client GetChecksum

### DIFF
--- a/checksum.go
+++ b/checksum.go
@@ -116,10 +116,7 @@ func (c *Client) extractChecksum(ctx context.Context, u *url.URL) (*FileChecksum
 
 	switch checksumType {
 	case "file":
-		req := &Request{
-			Src: checksumValue,
-		}
-		return c.ChecksumFromFile(ctx, req, u.Path)
+		return c.checksumFromFile(ctx, checksumValue, u.Path, "")
 	default:
 		return newChecksumFromType(checksumType, checksumValue, filepath.Base(u.EscapedPath()))
 	}
@@ -187,16 +184,16 @@ func newChecksumFromValue(checksumValue, filename string) (*FileChecksum, error)
 	return c, nil
 }
 
-// ChecksumFromFile will return the first file checksum found in the
+// checksumFromFile will return the first file checksum found in the
 // `checksumURL` file that corresponds to the `checksummedPath` path.
 //
-// ChecksumFromFile will infer the hashing algorithm based on the checksumURL
+// checksumFromFile will infer the hashing algorithm based on the checksumURL
 // file content.
 //
-// ChecksumFromFile will only return checksums for files that match
+// checksumFromFile will only return checksums for files that match
 // checksummedPath, which is the object being checksummed.
-func (c *Client) ChecksumFromFile(ctx context.Context, req *Request, checksummedPath string) (*FileChecksum, error) {
-	checksumFileURL, err := urlhelper.Parse(req.Src)
+func (c *Client) checksumFromFile(ctx context.Context, checksumURL string, checksummedPath string, pwd string) (*FileChecksum, error) {
+	checksumFileURL, err := urlhelper.Parse(checksumURL)
 	if err != nil {
 		return nil, err
 	}
@@ -207,8 +204,13 @@ func (c *Client) ChecksumFromFile(ctx context.Context, req *Request, checksummed
 	}
 	defer os.Remove(tempfile)
 
-	req.Dst = tempfile
-	req.Mode = ModeFile
+	req := &Request{
+		Pwd:  pwd,
+		Mode: ModeFile,
+		Src:  checksumURL,
+		Dst:  tempfile,
+		// ProgressListener: c.ProgressListener, TODO(adrien): pass progress bar ?
+	}
 
 	if _, err = c.Get(ctx, req); err != nil {
 		return nil, fmt.Errorf(
@@ -281,7 +283,59 @@ func (c *Client) ChecksumFromFile(ctx context.Context, req *Request, checksummed
 			return checksum, nil
 		}
 	}
-	return nil, fmt.Errorf("no checksum found in: %s", req.Src)
+	return nil, fmt.Errorf("no checksum found in: %s", checksumURL)
+}
+
+// GetChecksum extracts the checksum from the `checksum` parameter
+// of the src of the Request
+// ex:
+//  http://hashicorp.com/terraform?checksum=<checksumValue>
+//  http://hashicorp.com/terraform?checksum=<checksumType>:<checksumValue>
+//  http://hashicorp.com/terraform?checksum=file:<checksum_url>
+// when the checksum is in a file, GetChecksum will first client.Get it
+// in a temporary directory, parse the content of the file and finally delete it.
+// The content of a checksum file is expected to be BSD style or GNU style.
+// For security reasons GetChecksum does not try to get the current working directory
+// and as a result, relative files will only be found when Request.Pwd is set.
+//
+// BSD-style checksum:
+//  MD5 (file1) = <checksum>
+//  MD5 (file2) = <checksum>
+//
+// GNU-style:
+//  <checksum>  file1
+//  <checksum> *file2
+func (c *Client) GetChecksum(ctx context.Context, req *Request) (*FileChecksum, error) {
+	var err error
+	req.u, err = urlhelper.Parse(req.Src)
+	if err != nil {
+		return nil, err
+	}
+	q := req.u.Query()
+	v := q.Get("checksum")
+
+	if v == "" {
+		return nil, nil
+	}
+
+	vs := strings.SplitN(v, ":", 2)
+	switch len(vs) {
+	case 2:
+		break // good
+	default:
+		// here, we try to guess the checksum from it's length
+		// if the type was not passed
+		return newChecksumFromValue(v, filepath.Base(req.u.EscapedPath()))
+	}
+
+	checksumType, checksumValue := vs[0], vs[1]
+
+	switch checksumType {
+	case "file":
+		return c.checksumFromFile(ctx, checksumValue, req.u.Path, req.Pwd)
+	default:
+		return newChecksumFromType(checksumType, checksumValue, filepath.Base(req.u.EscapedPath()))
+	}
 }
 
 // parseChecksumLine takes a line from a checksum file and returns

--- a/checksum_test.go
+++ b/checksum_test.go
@@ -12,7 +12,10 @@ func TestClient_ChecksumFromFileWithSubFolder(t *testing.T) {
 	isoURL := "http://hashicorp.com/ubuntu/dists/bionic-updates/main/installer-amd64/current/images/netboot/mini.iso"
 
 	client := Client{}
-	file, err := client.ChecksumFromFile(ctx, httpChecksums.URL+"/sha256-subfolder.sum", isoURL)
+	req := &Request{
+		Src:              httpChecksums.URL+"/sha256-subfolder.sum",
+	}
+	file, err := client.ChecksumFromFile(ctx, req, isoURL)
 
 	if err != nil {
 		t.Fatalf("bad: should not have error: %s", err.Error())

--- a/checksum_test.go
+++ b/checksum_test.go
@@ -13,7 +13,7 @@ func TestClient_ChecksumFromFileWithSubFolder(t *testing.T) {
 
 	client := Client{}
 	req := &Request{
-		Src:              httpChecksums.URL+"/sha256-subfolder.sum",
+		Src: httpChecksums.URL + "/sha256-subfolder.sum",
 	}
 	file, err := client.ChecksumFromFile(ctx, req, isoURL)
 

--- a/checksum_test.go
+++ b/checksum_test.go
@@ -2,6 +2,9 @@ package getter
 
 import (
 	"context"
+	"io"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -12,10 +15,44 @@ func TestClient_ChecksumFromFileWithSubFolder(t *testing.T) {
 	isoURL := "http://hashicorp.com/ubuntu/dists/bionic-updates/main/installer-amd64/current/images/netboot/mini.iso"
 
 	client := Client{}
-	req := &Request{
-		Src: httpChecksums.URL + "/sha256-subfolder.sum",
+	file, err := client.checksumFromFile(ctx, httpChecksums.URL+"/sha256-subfolder.sum", isoURL, "")
+
+	if err != nil {
+		t.Fatalf("bad: should not have error: %s", err.Error())
 	}
-	file, err := client.ChecksumFromFile(ctx, req, isoURL)
+	if file.Filename != "./netboot/mini.iso" {
+		t.Fatalf("bad: expecting filename ./netboot/mini.iso but was: %s", file.Filename)
+	}
+}
+
+func TestClient_GetChecksum(t *testing.T) {
+	// Creates checksum file in local dir
+	p := filepath.Join(fixtureDir, "checksum-file/sha256-subfolder.sum")
+	source, err := os.Open(p)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	defer source.Close()
+	destination, err := os.Create("local.sum")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	defer os.Remove("local.sum")
+	defer destination.Close()
+	if _, err := io.Copy(destination, source); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	client := Client{}
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	req := &Request{
+		Src: "http://hashicorp.com/ubuntu/dists/bionic-updates/main/installer-amd64/current/images/netboot/mini.iso?checksum=file:./local.sum",
+		Pwd: wd,
+	}
+	file, err := client.GetChecksum(context.TODO(), req)
 
 	if err != nil {
 		t.Fatalf("bad: should not have error: %s", err.Error())

--- a/client.go
+++ b/client.go
@@ -142,7 +142,7 @@ func (c *Client) Get(ctx context.Context, req *Request) (*GetResult, error) {
 	}
 
 	// Determine checksum if we have one
-	checksum, err := c.extractChecksum(ctx, req.u)
+	checksum, err := c.GetChecksum(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("invalid checksum: %s", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,22 +5,15 @@ require (
 	github.com/aws/aws-sdk-go v1.15.78
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
 	github.com/cheggaaa/pb v1.0.27
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/fatih/color v1.7.0 // indirect
 	github.com/google/go-cmp v0.3.0
 	github.com/hashicorp/go-cleanhttp v0.5.0
+	github.com/hashicorp/go-getter v1.4.1
 	github.com/hashicorp/go-safetemp v1.0.0
 	github.com/hashicorp/go-version v1.1.0
-	github.com/mattn/go-colorable v0.0.9 // indirect
-	github.com/mattn/go-isatty v0.0.4 // indirect
-	github.com/mattn/go-runewidth v0.0.4 // indirect
 	github.com/mitchellh/go-homedir v1.0.0
 	github.com/mitchellh/go-testing-interface v1.0.0
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.2.2 // indirect
 	github.com/ulikunitz/xz v0.5.5
 	google.golang.org/api v0.9.0
-	gopkg.in/cheggaaa/pb.v1 v1.0.27 // indirect
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/hashicorp/go-cleanhttp v0.5.0 h1:wvCrVc9TjDls6+YGAF2hAifE1E5U1+b4tH6KdvN3Gig=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-getter v1.4.1 h1:3A2Mh8smGFcf5M+gmcv898mZdrxpseik45IpcyISLsA=
+github.com/hashicorp/go-getter v1.4.1/go.mod h1:7qxyCd8rBfcShwsvxgIguu4KbS3l8bUCwg2Umn7RjeY=
 github.com/hashicorp/go-safetemp v1.0.0 h1:2HR189eFNrjHQyENnQMMpCiBAsRxzbTMIgBhEyExpmo=
 github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=
 github.com/hashicorp/go-version v1.1.0 h1:bPIoEKD27tNdebFGGxxYwcL4nepeY4j1QP23PFRGzg0=


### PR DESCRIPTION
This PR makes checksumFromFile private and creates client GetChecksum which will receive a request and from that extract the checksum. 
To allow local files paths (e.g. `./file.sum`), the checksumFromFile method now receives the working dir as a parameter. 

This will close https://github.com/hashicorp/packer/issues/9047 together with https://github.com/hashicorp/packer/pull/9129