### PR TITLE
Make checksum func public

### DIFF
--- a/checksum.go
+++ b/checksum.go
@@ -48,10 +48,11 @@ func (cerr *ChecksumError) Error() string {
 	)
 }
 
-// checksum is a simple method to compute the checksum of a source file
-// and compare it to the given expected value.
-func (c *FileChecksum) checksum(source string) error {
-	f, err := os.Open(source)
+// Checksum computes the Checksum for file using the hashing algorithm from
+// c.Hash and compares it to c.Value. If those values differ a ChecksumError
+// will be returned.
+func (c *FileChecksum) Checksum(file string) error {
+	f, err := os.Open(file)
 	if err != nil {
 		return fmt.Errorf("Failed to open file for checksum: %s", err)
 	}
@@ -67,7 +68,7 @@ func (c *FileChecksum) checksum(source string) error {
 			Hash:     c.Hash,
 			Actual:   actual,
 			Expected: c.Value,
-			File:     source,
+			File:     file,
 		}
 	}
 

--- a/checksum.go
+++ b/checksum.go
@@ -55,11 +55,11 @@ func (cerr *ChecksumError) Error() string {
 	)
 }
 
-// Checksum computes the Checksum for file using the hashing algorithm from
+// Checksum computes the Checksum for filePath using the hashing algorithm from
 // c.Hash and compares it to c.Value. If those values differ a ChecksumError
 // will be returned.
-func (c *FileChecksum) Checksum(file string) error {
-	f, err := os.Open(file)
+func (c *FileChecksum) Checksum(filePath string) error {
+	f, err := os.Open(filePath)
 	if err != nil {
 		return fmt.Errorf("Failed to open file for checksum: %s", err)
 	}
@@ -75,7 +75,7 @@ func (c *FileChecksum) Checksum(file string) error {
 			Hash:     c.Hash,
 			Actual:   actual,
 			Expected: c.Value,
-			File:     file,
+			File:     filePath,
 		}
 	}
 

--- a/checksum.go
+++ b/checksum.go
@@ -27,6 +27,13 @@ type FileChecksum struct {
 	Filename string
 }
 
+// String returns the hash type and the hash separated by a colon, for example:
+//  "md5:090992ba9fd140077b0661cb75f7ce13"
+//  "sha1:ebfb681885ddf1234c18094a45bbeafd91467911"
+func (c *FileChecksum) String() string {
+	return c.Type + ":" + hex.EncodeToString(c.Value)
+}
+
 // A ChecksumError is returned when a checksum differs
 type ChecksumError struct {
 	Hash     hash.Hash

--- a/client.go
+++ b/client.go
@@ -181,7 +181,7 @@ func (c *Client) Get(ctx context.Context, req *Request) (*GetResult, error) {
 	if req.Mode == ModeFile {
 		getFile := true
 		if checksum != nil {
-			if err := checksum.checksum(req.Dst); err == nil {
+			if err := checksum.Checksum(req.Dst); err == nil {
 				// don't get the file if the checksum of dst is correct
 				getFile = false
 			}
@@ -193,7 +193,7 @@ func (c *Client) Get(ctx context.Context, req *Request) (*GetResult, error) {
 			}
 
 			if checksum != nil {
-				if err := checksum.checksum(req.Dst); err != nil {
+				if err := checksum.Checksum(req.Dst); err != nil {
 					return nil, err
 				}
 			}


### PR DESCRIPTION
Hello there, we needed that functionality as a standalone one in Packer as we have some internal code that uploads artifacts to a remote instance and we then need to checksum it.

We could have copied it since all the fields of `FileChecksum` are public but I thought this tiny improvement would be a little better.