### PR TITLE
Add check for .git directory at destination in GitGetter

### DIFF
--- a/get_git.go
+++ b/get_git.go
@@ -111,7 +111,8 @@ func (g *GitGetter) Get(dst string, u *url.URL) error {
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	if err == nil {
+
+	if err == nil && g.isGitRepo(dst) {
 		err = g.update(ctx, dst, sshKeyFile, ref, depth)
 	} else {
 		err = g.clone(ctx, dst, sshKeyFile, u, depth)
@@ -129,6 +130,17 @@ func (g *GitGetter) Get(dst string, u *url.URL) error {
 
 	// Lastly, download any/all submodules.
 	return g.fetchSubmodules(ctx, dst, sshKeyFile, depth)
+}
+
+// isGitRepo checks that given folder is a Git repository
+//
+func (g *GitGetter) isGitRepo(path string) bool {
+	_, err := os.Stat(filepath.Join(path, ".git"))
+	if err != nil && os.IsNotExist(err) {
+		return false
+	}
+
+	return true
 }
 
 // GetFile for Git doesn't support updating at this time. It will download

--- a/get_git_test.go
+++ b/get_git_test.go
@@ -242,6 +242,29 @@ func TestGitGetter_tag(t *testing.T) {
 	}
 }
 
+func TestGitGetter_isGitRepo(t *testing.T) {
+	if !testHasGit {
+		t.Skip("git not found, skipping")
+		return
+	}
+
+	t.Run("is-repo", func(t *testing.T) {
+		g := new(GitGetter)
+		repo := testGitRepo(t, "repo")
+		if !g.isGitRepo(repo.dir) {
+			t.Fatalf("unexpected false, %s is a git repository", repo.dir)
+		}
+	})
+
+	t.Run("is-not-repo", func(t *testing.T) {
+		g := new(GitGetter)
+		dir := tempDir(t)
+		if g.isGitRepo(dir) {
+			t.Fatalf("unexpected true, %s is not a repository", dir)
+		}
+	})
+}
+
 func TestGitGetter_GetFile(t *testing.T) {
 	if !testHasGit {
 		t.Skip("git not found, skipping")


### PR DESCRIPTION
Fixes #114 

- Adds check for git repository at destination(checks if `.git` folder exists)