### PR TITLE
Change the implementation of xz

### DIFF
--- a/decompress_txz.go
+++ b/decompress_txz.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/ulikunitz/xz"
+	"github.com/xi2/xz"
 )
 
 // TarXzDecompressor is an implementation of Decompressor that can
@@ -30,7 +30,7 @@ func (d *TarXzDecompressor) Decompress(dst, src string, dir bool) error {
 	defer f.Close()
 
 	// xz compression is second
-	txzR, err := xz.NewReader(f)
+	txzR, err := xz.NewReader(f, 0)
 	if err != nil {
 		return fmt.Errorf("Error opening an xz reader for %s: %s", src, err)
 	}

--- a/decompress_xz.go
+++ b/decompress_xz.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/ulikunitz/xz"
+	"github.com/xi2/xz"
 )
 
 // XzDecompressor is an implementation of Decompressor that can
@@ -32,7 +32,7 @@ func (d *XzDecompressor) Decompress(dst, src string, dir bool) error {
 	defer f.Close()
 
 	// xz compression is second
-	xzR, err := xz.NewReader(f)
+	xzR, err := xz.NewReader(f, 0)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/mitchellh/go-testing-interface v1.0.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2 // indirect
-	github.com/ulikunitz/xz v0.5.5
+	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8
 	google.golang.org/api v0.9.0
 	gopkg.in/cheggaaa/pb.v1 v1.0.27 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/ulikunitz/xz v0.5.5 h1:pFrO0lVpTBXLpYw+pnLj6TbvHuyjXMfjGeCwSqCVwok=
-github.com/ulikunitz/xz v0.5.5/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
+github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
+github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0 h1:C9hSCOW830chIVkdja34wa6Ky+IzWllkUinR+BtRZd4=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=


### PR DESCRIPTION
Decompression time is divided by 2.

With this file https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200629.3.0/x86_64/fedora-coreos-32.20200629.3.0-qemu.x86_64.qcow2.xz

github.com/ulikunitz/xz: 1m29s
github.com/xi2/xz: 42s