### PR TITLE
Add role option for S3 URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ are also supported. If the query parameters are present, these take priority.
   * `aws_access_key_secret` - AWS access key secret.
   * `aws_access_token` - AWS access token if this is being used.
   * `aws_profile` - Use this profile from local ~/.aws/ config. Takes priority over the other three.
+  * `aws_iam_role` - Use this role on-top of the other provided credentials. Is ignored when using a profile as that already has a way to describe the same.
 
 #### Using IAM Instance Profiles with S3
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/hashicorp/go-getter
 
 require (
 	cloud.google.com/go v0.45.1
-	github.com/aws/aws-sdk-go v1.15.78
+	github.com/aws/aws-sdk-go v1.34.31
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
 	github.com/cheggaaa/pb v1.0.27
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/aws/aws-sdk-go v1.15.78 h1:LaXy6lWR0YK7LKyuU0QWy2ws/LWTPfYV/UgfiBu4tvY=
 github.com/aws/aws-sdk-go v1.15.78/go.mod h1:E3/ieXAlvM0XWO57iftYVDLLvQ824smPP3ATZkfNZeM=
+github.com/aws/aws-sdk-go v1.34.31 h1:408wh5EHKzxyby8JpYfnn1w3fsF26AIU0o1kbJoRy7E=
+github.com/aws/aws-sdk-go v1.34.31/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/+8rV9s48=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d h1:xDfNPAt8lFiC1UJrqV3uuy861HCTo708pDMbjHHdCas=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ00z/TKoufEY6K/a0k6AhaJrQKdFe6OfVXsa4=
 github.com/cheggaaa/pb v1.0.27 h1:wIkZHkNfC7R6GI5w7l/PdAdzXzlrbcI3p8OAlnkTsnc=


### PR DESCRIPTION
Add support for specifying an IAM role that is assumed before making S3
requests. Beforehand this was only possible when using profiles which
required local files for configuration.

Now it is possible to specify such an IAM role in the URL, thereby
supporting settings where a IAM role needs to be assumed for data
access (e.g. cross-account).

Example of usage:
    s3::bucket.s3.amazonaws.com/file?aws_iam_role=some-role-arn

This currently only has a negative test case as I do not have access to the used AWS account. If someone could help me with details to write a positive test case as well, that would be much appreciated.