### PR TITLE
deps: Update github.com/ulikunitz/xz@v0.5.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/go-version v1.1.0
 	github.com/mitchellh/go-homedir v1.0.0
 	github.com/mitchellh/go-testing-interface v1.0.0
-	github.com/ulikunitz/xz v0.5.5
+	github.com/ulikunitz/xz v0.5.8
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -18,3 +18,5 @@ github.com/mitchellh/go-testing-interface v1.0.0 h1:fzU/JVNcaqHQEcVFAKeR41fkiLdI
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/ulikunitz/xz v0.5.5 h1:pFrO0lVpTBXLpYw+pnLj6TbvHuyjXMfjGeCwSqCVwok=
 github.com/ulikunitz/xz v0.5.5/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
+github.com/ulikunitz/xz v0.5.8 h1:ERv8V6GKqVi23rgu5cj9pVfVzJbOqAY2Ntl88O6c2nQ=
+github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=


### PR DESCRIPTION
Addresses CVE-2020-16845.

Reference:
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-16845
Reference: GHSA-25xm-hr59-7c27
Reference: ulikunitz/xz#35