### PR TITLE
detector/bitbucket: Remove support for hg URL schema

### DIFF
--- a/detect_bitbucket.go
+++ b/detect_bitbucket.go
@@ -58,8 +58,6 @@ func (d *BitBucketDetector) detectHTTP(src string) (string, bool, error) {
 		}
 
 		return "git::" + u.String(), true, nil
-	case "hg":
-		return "hg::" + u.String(), true, nil
 	default:
 		return "", true, fmt.Errorf("unknown BitBucket SCM type: %s", info.SCM)
 	}

--- a/detect_bitbucket_test.go
+++ b/detect_bitbucket_test.go
@@ -29,10 +29,6 @@ func TestBitBucketDetector(t *testing.T) {
 			"bitbucket.org/hashicorp/tf-test-git.git",
 			"git::https://bitbucket.org/hashicorp/tf-test-git.git",
 		},
-		{
-			"bitbucket.org/hashicorp/tf-test-hg",
-			"hg::https://bitbucket.org/hashicorp/tf-test-hg",
-		},
 	}
 
 	pwd := "/pwd"

--- a/get_hg_test.go
+++ b/get_hg_test.go
@@ -2,11 +2,9 @@ package getter
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	testing_helper "github.com/hashicorp/go-getter/v2/helper/testing"
@@ -119,55 +117,4 @@ func TestHgGetter_GetFile(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 	testing_helper.AssertContents(t, dst, "Hello\n")
-}
-
-func TestHgGetter_DetectBitBucketDetector(t *testing.T) {
-	t.Parallel()
-
-	if _, err := http.Get(testBBUrl); err != nil {
-		t.Log("internet may not be working, skipping BB tests")
-		t.Skip()
-	}
-
-	cases := []struct {
-		Input  string
-		Output string
-	}{
-		{
-			"bitbucket.org/hashicorp/tf-test-hg",
-			"https://bitbucket.org/hashicorp/tf-test-hg",
-		},
-	}
-
-	pwd := "/pwd"
-	for i, tc := range cases {
-		var err error
-		for i := 0; i < 3; i++ {
-			var ok bool
-			req := &Request{
-				Src: tc.Input,
-				Pwd: pwd,
-			}
-			ok, err = Detect(req, new(HgGetter))
-			if err != nil {
-				if strings.Contains(err.Error(), "invalid character") {
-					continue
-				}
-
-				t.Fatalf("err: %s", err)
-			}
-			if !ok {
-				t.Fatal("not ok")
-			}
-
-			if req.Src != tc.Output {
-				t.Fatalf("%d: bad: %#v", i, req.Src)
-			}
-
-			break
-		}
-		if i >= 3 {
-			t.Fatalf("failure from bitbucket: %s", err)
-		}
-	}
 }


### PR DESCRIPTION
This change removes hg as a supported schema for the BitBucket detector as Mercurial enabled repositories are not longer supported by BitBucket.

Official announcement at https://bitbucket.org/blog/sunsetting-mercurial-support-in-bitbucket.

Test results before change
```
--- FAIL: TestHgGetter_DetectBitBucketDetector (0.52s)
    get_hg_test.go:157: err: unknown BitBucket SCM type:
--- FAIL: TestBitBucketDetector (0.61s)
    detect_bitbucket_test.go:51: err: unknown BitBucket SCM type:
FAIL
FAIL    github.com/hashicorp/go-getter/v2       6.240s
```

Test results after change
```
ok      github.com/hashicorp/go-getter/v2       6.102s
```