### PR TITLE
Fix bug in Detect() where a Windows-style absolute path is not translated properly

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -48,7 +48,7 @@ func Detect(src string, pwd string, ds []Detector) (string, error) {
 	getSrc, subDir := SourceDirSubdir(getSrc)
 
 	u, err := url.Parse(getSrc)
-	if err == nil && u.Scheme != "" {
+	if err == nil && u.Scheme != "" && u.Scheme != "file" {
 		// Valid URL
 		return src, nil
 	}

--- a/detect_test.go
+++ b/detect_test.go
@@ -13,6 +13,8 @@ func TestDetect(t *testing.T) {
 		Err    bool
 	}{
 		{"./foo", "/foo", "file:///foo/foo", false},
+		{`X:\foo\bar`, `X:\baz`, `file://X:/foo/bar`, false}, // Windows-style full path with drive letter
+		{`.\bar`, `X:\foo`, `file://X:/foo/bar`, false},      // Windows-style relative path
 		{"git::./foo", "/foo", "git::file:///foo/foo", false},
 		{
 			"git::github.com/hashicorp/foo",


### PR DESCRIPTION
When calling `Detect()` with a Windows-style absolute path, it is detected to be a valid URL by `url.Parse()` and returned directly, without applying the `file://` prefix, like other file paths.

This PR excludes file scheme URLs from directly returning if successfully parsed, allowing them to flow down and be handled by `FileDetector`, which takes care of applying the `file://` prefix.

This PR adds unit test cases covering Windows-style path scenarios.