### PR TITLE
Support file matching for directories

### DIFF
--- a/client.go
+++ b/client.go
@@ -67,6 +67,10 @@ type Client struct {
 	// By default a no op progress listener is used.
 	ProgressListener ProgressTracker
 
+	// FileMatches allows to filter files that should be fetched from a source directory
+	// By default, all files are matched
+	FileMatches FileMatcher
+
 	Options []ClientOption
 }
 

--- a/client_option.go
+++ b/client_option.go
@@ -10,6 +10,11 @@ func (c *Client) Configure(opts ...ClientOption) error {
 	if c.Ctx == nil {
 		c.Ctx = context.Background()
 	}
+
+	c.FileMatches = func(string, string) bool {
+		return true
+	}
+
 	c.Options = opts
 	for _, opt := range opts {
 		err := opt(c)

--- a/client_option_matching_files.go
+++ b/client_option_matching_files.go
@@ -1,0 +1,29 @@
+package getter
+
+import (
+	"regexp"
+	"strings"
+)
+
+// FileMatcher allows to filter files based on their source and name
+type FileMatcher = func(source, fullFilename string) bool
+
+// WithFileMatcher adds a FileMatcher to the client
+// Any kind of function that returns a boolean from file properties can be used
+func WithFileMatcher(fm FileMatcher) func(*Client) error {
+	return func(c *Client) error {
+		c.FileMatches = fm
+		return nil
+	}
+}
+
+// WithFileMatcher adds a regex FileMatcher to the client
+func WithRegexFileMatcher(regex string) func(*Client) error {
+	return func(c *Client) error {
+		expression, err := regexp.Compile(regex)
+		c.FileMatches = func(source, fullFilename string) bool {
+			return expression.MatchString(fullFilename) || expression.MatchString((strings.TrimPrefix(fullFilename, source)))
+		}
+		return err
+	}
+}

--- a/get_s3.go
+++ b/get_s3.go
@@ -117,6 +117,9 @@ func (g *S3Getter) Get(dst string, u *url.URL) error {
 		for _, object := range resp.Contents {
 			lastMarker = aws.StringValue(object.Key)
 			objPath := aws.StringValue(object.Key)
+			if !g.client.FileMatches(path, objPath) {
+				continue
+			}
 
 			// If the key ends with a backslash assume it is a directory and ignore
 			if strings.HasSuffix(objPath, "/") {


### PR DESCRIPTION
**Note**: Opening as a draft because I want your input before I go on and add this to every provider. Right now, it works great for S3. Is this something that fits with your vision of the tool?

This allows go-getter to not download everything in a folder

Our usecase is that our S3 bucket contains large files and metadata and we want to only get metadata
With this, we can set a filename regex on the extension