### PR TITLE
Switch to docker mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ commands:
 jobs:
   linux-tests:
     docker:
-      - image: circleci/golang:<< parameters.go-version >>
+      - image: docker.mirror.hashicorp.services/circleci/golang:<< parameters.go-version >>
     parameters:
       go-version:
         type: string


### PR DESCRIPTION
Instead of using dockerhub (which will enforce rate limiting on anonymous image pulls starting Nov 1st), we're moving projects to our mirror at `docker.mirror.hashicorp.services`. LMK if you have any q's, otherwise feel free to approve and merge on your own! 
