### PR TITLE
Remove go tests from goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,3 @@
-before:
-  hooks:
-    - go test ./...
-
 builds:
   - id: signable
     mod_timestamp: '{{ .CommitTimestamp }}'


### PR DESCRIPTION
Since these require secrets to run and are already run in CircleCI, there's no reason to run them in github actions. 