### PR TITLE
Fixes #299

### DIFF
--- a/get_git.go
+++ b/get_git.go
@@ -266,9 +266,9 @@ func setupGitEnv(cmd *exec.Cmd, sshKeyFile string) {
 			sshKeyFile = strings.Replace(sshKeyFile, `\`, `/`, -1)
 		}
 		sshCmd = append(sshCmd, "-i", sshKeyFile)
+		env = append(env, strings.Join(sshCmd, " "))
 	}
 
-	env = append(env, strings.Join(sshCmd, " "))
 	cmd.Env = env
 }
 


### PR DESCRIPTION
Does not override GIT_SSH_COMMAND when not needed. See #299 .