### PR TITLE
Set GOPRIVATE env var

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,6 @@
+env:
+  - GOPRIVATE=github.com/hashicorp
+
 builds:
   - id: signable
     mod_timestamp: '{{ .CommitTimestamp }}'


### PR DESCRIPTION
The goreleaser release pipeline that was created and used for the 1.5.1 release was missing the GOPRIVATE env var being set, which caused private modules to be skipped. This change is being made [in code](https://goreleaser.com/customization/env/) so that it's visible to users. After it's merged, we'll kick off the v1.5.2 release. 