### PR TITLE
Add support for gcs object generations

### DIFF
--- a/get_gcs.go
+++ b/get_gcs.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -135,8 +134,7 @@ func (g *GCSGetter) GetFile(dst string, u *url.URL) error {
 func (g *GCSGetter) getObject(ctx context.Context, client *storage.Client, dst, bucket, object, fragment string) error {
 	var rc *storage.Reader
 	var err error
-	fragmentHasGeneration := regexp.MustCompile("^\\d+$").MatchString(fragment)
-	if fragmentHasGeneration {
+	if fragment != "" {
 		generation, err := strconv.ParseInt(fragment, 10, 64)
 		if err != nil {
 			return err

--- a/get_gcs.go
+++ b/get_gcs.go
@@ -124,7 +124,6 @@ func (g *GCSGetter) GetFile(dst string, u *url.URL) error {
 	if err != nil {
 		return err
 	}
-	fmt.Println(object)
 
 	client, err := storage.NewClient(ctx)
 	if err != nil {

--- a/get_gcs_test.go
+++ b/get_gcs_test.go
@@ -125,7 +125,7 @@ func TestGCSGetter_GetGenerationFile(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 	if string(content) != "b" {
-		t.Fatalf("expected file contents from generation to be `a` but got `%s`", content)
+		t.Fatalf("expected file contents from generation to be `b` but got `%s`", content)
 	}
 
 }

--- a/get_gcs_test.go
+++ b/get_gcs_test.go
@@ -1,6 +1,7 @@
 package getter
 
 import (
+	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -86,6 +87,47 @@ func TestGCSGetter_GetFile(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 	assertContents(t, dst, "# Main\n")
+}
+
+func TestGCSGetter_GetGenerationFile(t *testing.T) {
+	defer initGCPCredentials(t)()
+
+	g := new(GCSGetter)
+	dst := tempTestFile(t)
+	defer os.RemoveAll(filepath.Dir(dst))
+
+	// Download
+	err := g.GetFile(
+		dst, testURL("https://www.googleapis.com/storage/v1/go-getter-testcase-data/DO_NOT_DELETE/generation_test.txt#1614317688843055"))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Verify the main file exists
+	content, err := ioutil.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if string(content) != "a" {
+		t.Fatalf("expected file contents from generation to be `a` but got `%s`", content)
+	}
+
+	// Download
+	err = g.GetFile(
+		dst, testURL("https://www.googleapis.com/storage/v1/go-getter-testcase-data/DO_NOT_DELETE/generation_test.txt#1614317705239142"))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Verify the main file exists
+	content, err = ioutil.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if string(content) != "b" {
+		t.Fatalf("expected file contents from generation to be `a` but got `%s`", content)
+	}
+
 }
 
 func TestGCSGetter_GetFile_notfound(t *testing.T) {
@@ -180,7 +222,7 @@ func TestGCSGetter_Url(t *testing.T) {
 				t.Fatalf("expected forced protocol to be gcs")
 			}
 
-			bucket, path, err := g.parseURL(u)
+			bucket, path, _, err := g.parseURL(u)
 
 			if err != nil {
 				t.Fatalf("err: %s", err)

--- a/get_gcs_test.go
+++ b/get_gcs_test.go
@@ -103,7 +103,7 @@ func TestGCSGetter_GetGenerationFile(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	// Verify the main file exists
+	// Verify contents are valid for this generation
 	content, err := ioutil.ReadFile(dst)
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -119,7 +119,7 @@ func TestGCSGetter_GetGenerationFile(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	// Verify the main file exists
+	// Verify contents are valid for this generation
 	content, err = ioutil.ReadFile(dst)
 	if err != nil {
 		t.Fatalf("err: %s", err)


### PR DESCRIPTION
Adding support for gcs generations. These are essentially versioned objects in gcs buckets annotated by [a hash at the end of the url](https://cloud.google.com/storage/docs/object-versioning). 