### PR TITLE
Add support to detect 5 parts s3 virtual hosted-style requests

### DIFF
--- a/detect_s3_test.go
+++ b/detect_s3_test.go
@@ -34,6 +34,11 @@ func TestS3Detector(t *testing.T) {
 			"bucket.s3-eu-west-1.amazonaws.com/foo/bar.baz",
 			"s3::https://s3-eu-west-1.amazonaws.com/bucket/foo/bar.baz",
 		},
+		// 5 parts Virtual hosted-style
+		{
+			"bucket.s3.eu-west-1.amazonaws.com/foo/bar.baz",
+			"s3::https://s3.eu-west-1.amazonaws.com/bucket/foo/bar.baz",
+		},
 		// Path style
 		{
 			"s3.amazonaws.com/bucket/foo",


### PR DESCRIPTION
looking at aws doc 
https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#virtual-hosted-style-access

the new s3 virtual hosted-style has 5 hostParts 
https://bucket-name.s3.Region.amazonaws.com/key-name

this PR is to enhance the S3Detector, so it recognize this new s3 style.