### PR TITLE
Add insecure flag for http getter.

### DIFF
--- a/client.go
+++ b/client.go
@@ -67,6 +67,15 @@ type Client struct {
 	// By default a no op progress listener is used.
 	ProgressListener ProgressTracker
 
+	// Insecure controls whether a client verifies the server's
+	// certificate chain and host name. If Insecure is true, crypto/tls
+	// accepts any certificate presented by the server and any host name in that
+	// certificate. In this mode, TLS is susceptible to machine-in-the-middle
+	// attacks unless custom verification is used. This should be used only for
+	// testing or in combination with VerifyConnection or VerifyPeerCertificate.
+	// This is identical to tls.Config.InsecureSkipVerify.
+	Insecure bool
+
 	Options []ClientOption
 }
 

--- a/client.go
+++ b/client.go
@@ -298,7 +298,7 @@ func (c *Client) Get() error {
 		// if we're specifying a subdir.
 		err := g.Get(dst, u)
 		if err != nil {
-			err = fmt.Errorf("error downloading '%s': %s", src, err)
+			err = fmt.Errorf("error downloading '%s': %s", u.Redacted(), err)
 			return err
 		}
 	}

--- a/client_option_insecure.go
+++ b/client_option_insecure.go
@@ -5,7 +5,7 @@ package getter
 // For example, when connecting on HTTPS where an
 // invalid certificate is presented.
 // User assumes all risk.
-// Not all getters have progress support yet.
+// Not all getters have support for insecure mode yet.
 func WithInsecure() func(*Client) error {
 	return func(c *Client) error {
 		c.Insecure = true

--- a/client_option_insecure.go
+++ b/client_option_insecure.go
@@ -1,0 +1,14 @@
+package getter
+
+// WithInsecure allows for a user to avoid
+// checking certificates (not recommended).
+// For example, when connecting on HTTPS where an
+// invalid certificate is presented.
+// User assumes all risk.
+// Not all getters have progress support yet.
+func WithInsecure() func(*Client) error {
+	return func(c *Client) error {
+		c.Insecure = true
+		return nil
+	}
+}

--- a/cmd/go-getter/main.go
+++ b/cmd/go-getter/main.go
@@ -14,6 +14,7 @@ import (
 func main() {
 	modeRaw := flag.String("mode", "any", "get mode (any, file, dir)")
 	progress := flag.Bool("progress", false, "display terminal progress")
+	insecure := flag.Bool("insecure", false, "do not verify server's certificate chain (not recommended)")
 	flag.Parse()
 	args := flag.Args()
 	if len(args) < 2 {
@@ -44,6 +45,11 @@ func main() {
 	opts := []getter.ClientOption{}
 	if *progress {
 		opts = append(opts, getter.WithProgress(defaultProgressBar))
+	}
+
+	if *insecure {
+		log.Println("WARNING: Using Insecure TLS transport!")
+		opts = append(opts, getter.WithInsecure())
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/get_http.go
+++ b/get_http.go
@@ -2,6 +2,7 @@ package getter
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/xml"
 	"fmt"
 	"io"
@@ -11,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/hashicorp/go-cleanhttp"
 	safetemp "github.com/hashicorp/go-safetemp"
 )
 
@@ -74,6 +76,11 @@ func (g *HttpGetter) Get(dst string, u *url.URL) error {
 
 	if g.Client == nil {
 		g.Client = httpClient
+		if g.client != nil && g.client.Insecure {
+			insecureTransport := cleanhttp.DefaultTransport()
+			insecureTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+			g.Client.Transport = insecureTransport
+		}
 	}
 
 	// Add terraform-get to the parameter.
@@ -157,6 +164,11 @@ func (g *HttpGetter) GetFile(dst string, src *url.URL) error {
 
 	if g.Client == nil {
 		g.Client = httpClient
+		if g.client != nil && g.client.Insecure {
+			insecureTransport := cleanhttp.DefaultTransport()
+			insecureTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+			g.Client.Transport = insecureTransport
+		}
 	}
 
 	var currentFileSize int64


### PR DESCRIPTION
I have a need to use `go-getter` without checking the certificate chain on the http server. To accomplish this I've added a flag named `-insecure` that will allow me to do this. I've tried to add tons of warnings in the code and in the tool to make users aware what a bad idea it is to use this flag and that they are taking risks.

Prior to using this flag I would see:

```text
2021/04/28 14:11:06 Error downloading: Get "https://username:***@hostname": x509: cannot validate certificate for hostname because it doesn't contain any IP SANs
```

After adding the flag I get this message:

```text
2021/04/28 14:37:17 WARNING: Using Insecure TLS transport!
2021/04/28 14:37:17 success!
```

I am unsure how to add a test that shows this without also bootstrapping a server with bad TLS in the tests, but if that's needed I can do it. I've also tried to follow the paradigms in the code but if I've missed something I can fix it.

Finally, I noticed that one of the error messages kept spitting out an unredacted password in a URI. I added that as a security fix here but I'm happy to remove it and submit another PR.
