### PR TITLE
fixes #320: Pass context to NewRequestWithContext so HTTP requests can…

### DIFF
--- a/get_http.go
+++ b/get_http.go
@@ -80,7 +80,7 @@ func (g *HttpGetter) Get(ctx context.Context, req *Request) error {
 	req.u.RawQuery = q.Encode()
 
 	// Get the URL
-	httpReq, err := http.NewRequest("GET", req.u.String(), nil)
+	httpReq, err := http.NewRequestWithContext(ctx, "GET", req.u.String(), nil)
 	if err != nil {
 		return err
 	}
@@ -161,7 +161,7 @@ func (g *HttpGetter) GetFile(ctx context.Context, req *Request) error {
 	// We first make a HEAD request so we can check
 	// if the server supports range queries. If the server/URL doesn't
 	// support HEAD requests, we just fall back to GET.
-	httpReq, err := http.NewRequest("HEAD", req.u.String(), nil)
+	httpReq, err := http.NewRequestWithContext(ctx, "HEAD", req.u.String(), nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fix for #320 for the `v2` branch. More or less the same test + fix.