### PR TITLE
Honor copy=true in directory mode for local file copies

### DIFF
--- a/get_file_unix.go
+++ b/get_file_unix.go
@@ -45,7 +45,11 @@ func (g *FileGetter) Get(dst string, u *url.URL) error {
 		return err
 	}
 
-	return os.Symlink(path, dst)
+	if !g.Copy {
+		return os.Symlink(path, dst)
+	}
+
+	return copyDir(g.Context(), dst, path, false, g.client.umask())
 }
 
 func (g *FileGetter) GetFile(dst string, u *url.URL) error {


### PR DESCRIPTION
This looks like an oversight: when getting local files, directory copies always result in a symlink. This may not be desirable in all use cases.
