### PR TITLE
Pass signore client ID and secret to releaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,8 +67,8 @@ jobs:
           ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
           CIRCLE_TOKEN: ${{ secrets.CIRCLE_TOKEN }}
           SIGNORE_SIGNER: ${{secrets.SIGNORE_SIGNER}}
-          SIGNORE_CLIENT_ID: $${{secrets.SIGNORE_CLIENT_ID}
-          SIGNORE_CLIENT_SECRET: $${{secrets.SIGNORE_CLIENT_SECRET}
+          SIGNORE_CLIENT_ID: ${{secrets.SIGNORE_CLIENT_ID}}
+          SIGNORE_CLIENT_SECRET: ${{secrets.SIGNORE_CLIENT_SECRET}}
       - name: Run clamAV antivirus scanner
         run: sudo clamscan /home/runner/work/$REPO/$REPO/dist/
         env:
@@ -77,4 +77,3 @@ jobs:
         run: sudo maldet -a /home/runner/work/$REPO/$REPO/dist/
         env:
           REPO: ${{ github.event.repository.name }}
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,8 @@ jobs:
           ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
           CIRCLE_TOKEN: ${{ secrets.CIRCLE_TOKEN }}
           SIGNORE_SIGNER: ${{secrets.SIGNORE_SIGNER}}
+          SIGNORE_CLIENT_ID: $${{secrets.SIGNORE_CLIENT_ID}
+          SIGNORE_CLIENT_SECRET: $${{secrets.SIGNORE_CLIENT_SECRET}
       - name: Run clamAV antivirus scanner
         run: sudo clamscan /home/runner/work/$REPO/$REPO/dist/
         env:


### PR DESCRIPTION
The release job is failing because the signore client ID and secret have not been set in the release job: https://github.com/hashicorp/go-getter/runs/3167243861. These are passed in to the [setup-signore job](https://github.com/hashicorp/go-getter/commit/d4be3502b44c5acc628bdffdf230189cf5e0136b), but it seems they also need to be made available explicitly in the goreleaser context. This PR is meant to address that. 