### PR TITLE
Fix virtual hosted style s3 detector

### DIFF
--- a/detect_s3.go
+++ b/detect_s3.go
@@ -63,7 +63,7 @@ func (d *S3Detector) detectVhostStyle(region, bucket string, parts []string) (st
 }
 
 func (d *S3Detector) detectNewVhostStyle(region, bucket string, parts []string) (string, bool, error) {
-	urlStr := fmt.Sprintf("https://s3.%s.amazonaws.com/%s/%s", region, bucket, strings.Join(parts, "/"))
+	urlStr := fmt.Sprintf("https://%s.s3.%s.amazonaws.com/%s", bucket, region, strings.Join(parts, "/"))
 	url, err := url.Parse(urlStr)
 	if err != nil {
 		return "", false, fmt.Errorf("error parsing S3 URL: %s", err)

--- a/detect_s3_test.go
+++ b/detect_s3_test.go
@@ -37,7 +37,7 @@ func TestS3Detector(t *testing.T) {
 		// 5 parts Virtual hosted-style
 		{
 			"bucket.s3.eu-west-1.amazonaws.com/foo/bar.baz",
-			"s3::https://s3.eu-west-1.amazonaws.com/bucket/foo/bar.baz",
+			"s3::https://bucket.s3.eu-west-1.amazonaws.com/foo/bar.baz",
 		},
 		// Path style
 		{


### PR DESCRIPTION
Hosted-Style  should be this format
https://bucket.s3.eu-west-1.amazonaws.com/foo/bar.baz

previous PR translated 5 parts s3 url to Path-Style Requests