### PR TITLE
release.yml: stop writing signore secrets to disk

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,6 @@ jobs:
         uses: hashicorp/setup-signore@v1
         with:
           github-token: ${{secrets.SIGNORE_TOKEN}}
-          client-id: $${{secrets.SIGNORE_CLIENT_ID}}
-          client-secret: $${{secrets.SIGNORE_CLIENT_SECRET}}
       - name: Install hc-codesign
         id: codesign
         run: |


### PR DESCRIPTION
we're setting signore secrets in the goreleaser step's environment, so there is no reason to have `setup-signore` configure them as well