### PR TITLE
fix(decompresser_zip): fix panic when decompressing protected zip file (#343)

### DIFF
--- a/decompress_zip.go
+++ b/decompress_zip.go
@@ -74,7 +74,9 @@ func (d *ZipDecompressor) Decompress(dst, src string, dir bool, umask os.FileMod
 		// Open the file for reading
 		srcF, err := f.Open()
 		if err != nil {
-			srcF.Close()
+			if srcF != nil {
+				srcF.Close()
+			}
 			return err
 		}
 


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

Added check if file is nil before trying to close preventing unwanted panic