### PR TITLE
Redact SSH key from URL query parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+cmd/go-getter/go-getter

--- a/url.go
+++ b/url.go
@@ -13,7 +13,12 @@ func RedactURL(u *url.URL) string {
 
 	ru := *u
 	if _, has := ru.User.Password(); has {
-		ru.User = url.UserPassword(ru.User.Username(), "xxxxx")
+		ru.User = url.UserPassword(ru.User.Username(), "redacted")
+	}
+	q := ru.Query()
+	if q.Get("sshkey") != "" {
+		q.Set("sshkey", "redacted")
+		ru.RawQuery = q.Encode()
 	}
 	return ru.String()
 }

--- a/url.go
+++ b/url.go
@@ -3,9 +3,10 @@ package getter
 import "net/url"
 
 // RedactURL is a port of url.Redacted from the standard library,
-// which is like url.String but replaces any password with "xxxxx".
+// which is like url.String but replaces any password with "redacted".
 // Only the password in u.URL is redacted. This allows the library
 // to maintain compatibility with go1.14.
+// This port was also extended to redact SSH key from URL query parameter.
 func RedactURL(u *url.URL) string {
 	if u == nil {
 		return ""

--- a/url_test.go
+++ b/url_test.go
@@ -19,7 +19,7 @@ func TestRedactURL(t *testing.T) {
 				Path:   "this:that",
 				User:   url.UserPassword("user", "password"),
 			},
-			want: "http://user:xxxxx@host.tld/this:that",
+			want: "http://user:redacted@host.tld/this:that",
 		},
 		{
 			name: "blank Password",
@@ -39,7 +39,7 @@ func TestRedactURL(t *testing.T) {
 				Path:   "this:that",
 				User:   url.UserPassword("", "password"),
 			},
-			want: "http://:xxxxx@host.tld/this:that",
+			want: "http://:redacted@host.tld/this:that",
 		},
 		{
 			name: "blank Username, blank Password",
@@ -59,6 +59,28 @@ func TestRedactURL(t *testing.T) {
 			name: "nil URL",
 			url:  nil,
 			want: "",
+		},
+		{
+			name: "non-blank SSH key in URL query parameter",
+			url: &url.URL{
+				Scheme:   "ssh",
+				User:     url.User("git"),
+				Host:     "github.com",
+				Path:     "hashicorp/go-getter-test-private.git",
+				RawQuery: "sshkey=LS0tLS1CRUdJTiBPUE",
+			},
+			want: "ssh://git@github.com/hashicorp/go-getter-test-private.git?sshkey=redacted",
+		},
+		{
+			name: "blank SSH key in URL query parameter",
+			url: &url.URL{
+				Scheme:   "ssh",
+				User:     url.User("git"),
+				Host:     "github.com",
+				Path:     "hashicorp/go-getter-test-private.git",
+				RawQuery: "sshkey=",
+			},
+			want: "ssh://git@github.com/hashicorp/go-getter-test-private.git?sshkey=",
 		},
 	}
 


### PR DESCRIPTION
This PR changes:

1. Redact SSH key from URL query parameter when printing the URL after a download error happens.
2. Changed redaction from `xxxxx` to `redacted`.
3. Added two tests for the SSH key redaction.
4. Added `.gitignore`.

Signed-off-by: Guilherme Macedo <guilherme.macedo@suse.com>