### PR TITLE
Append tar and ova decompressor in v2

### DIFF
--- a/decompress.go
+++ b/decompress.go
@@ -23,6 +23,7 @@ type Decompressor interface {
 var Decompressors map[string]Decompressor
 
 func init() {
+	tarDecompressor := new(TarDecompressor)
 	tbzDecompressor := new(TarBzip2Decompressor)
 	tgzDecompressor := new(TarGzipDecompressor)
 	txzDecompressor := new(TarXzDecompressor)
@@ -38,6 +39,8 @@ func init() {
 		"tgz":     tgzDecompressor,
 		"txz":     txzDecompressor,
 		"zip":     new(ZipDecompressor),
+		"tar":     tarDecompressor,
+		"ova":     tarDecompressor,
 	}
 }
 

--- a/decompress_tar.go
+++ b/decompress_tar.go
@@ -125,11 +125,11 @@ func untar(input io.Reader, dst, src string, dir bool, umask os.FileMode) error 
 	return nil
 }
 
-// tarDecompressor is an implementation of Decompressor that can
+// TarDecompressor is an implementation of Decompressor that can
 // unpack tar files.
-type tarDecompressor struct{}
+type TarDecompressor struct{}
 
-func (d *tarDecompressor) Decompress(dst, src string, dir bool, umask os.FileMode) error {
+func (d *TarDecompressor) Decompress(dst, src string, dir bool, umask os.FileMode) error {
 	// If we're going into a directory we should make that first
 	mkdir := dst
 	if !dir {

--- a/decompress_tar_test.go
+++ b/decompress_tar_test.go
@@ -42,7 +42,7 @@ func TestTar(t *testing.T) {
 		cases[i].Input = filepath.Join("./testdata", "decompress-tar", tc.Input)
 	}
 
-	TestDecompressor(t, new(tarDecompressor), cases)
+	TestDecompressor(t, new(TarDecompressor), cases)
 }
 
 // testDecompressPermissions decompresses a directory and checks the permissions of the expanded files
@@ -76,7 +76,7 @@ func testDecompressorPermissions(t *testing.T, d Decompressor, input string, exp
 }
 
 func TestDecompressTarPermissions(t *testing.T) {
-	d := new(tarDecompressor)
+	d := new(TarDecompressor)
 	input := "./test-fixtures/decompress-tar/permissions.tar"
 
 	var expected map[string]int


### PR DESCRIPTION
Hello,

I try to implement this issue https://github.com/hashicorp/packer-plugin-qemu/issues/7.
The plugin use `go-getter` v2 for decompress archive, however `tar` or `ova` are unsupported in this version.

So I append `tar` support. I cherry-pick the commit 6a2a0516f4917e30a3e3e00593081a6b1273a8ab and append two new entries in the decompressor map.