### PR TITLE
Removed ova file type from the list of supported decompressors

### DIFF
--- a/decompress.go
+++ b/decompress.go
@@ -40,7 +40,6 @@ func init() {
 		"txz":     txzDecompressor,
 		"zip":     new(ZipDecompressor),
 		"tar":     tarDecompressor,
-		"ova":     tarDecompressor,
 	}
 }
 


### PR DESCRIPTION
This change removes ova files from the list of files to decompress upon downloading. Support for decompressing ova files was added in https://github.com/hashicorp/go-getter/pull/351. Which has caused a regression in the Virtualbox plugin for Packer https://github.com/hashicorp/packer/issues/11631.

Thinking about ova files, I wouldn't expect go-getter to treat them as a tarball but instead as a single file to be consumed downstream. An alternative to removing ova from the list of decompressors would be to add the archive=false query parameter to the source path in the Virtualbox plugin (possibly other plugins as well). But I opted not to go that route because the decompressing of ova files seems like an expected behavior.

If having the ova file extension listed as a decompressor is necessary then we may want to consider adding a separate decompressor type with updated logic specifically for ova files, possibly in a minor release.  