### PR TITLE
Fix support for getting single files from GitHub (v2)

### DIFF
--- a/get_github_test.go
+++ b/get_github_test.go
@@ -1,0 +1,76 @@
+package getter
+
+import (
+	"context"
+	testing_helper "github.com/hashicorp/go-getter/v2/helper/testing"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const basicMainTFExpectedContents = `# Hello
+
+module "foo" {
+    source = "./foo"
+}
+`
+
+func TestGitGetter_githubDirWithModeAny(t *testing.T) {
+	if !testHasGit {
+		t.Skip("git not found, skipping")
+	}
+
+	ctx := context.Background()
+	dst := testing_helper.TempDir(t)
+	defer os.RemoveAll(dst)
+
+	req := &Request{
+		Src:     "git::https://github.com/arikkfir/go-getter.git//testdata/basic?ref=v2",
+		Dst:     dst,
+		GetMode: ModeAny,
+		Copy:    true,
+	}
+	client := Client{}
+	result, err := client.Get(ctx, req)
+	if err != nil {
+		t.Fatalf("Failed fetching GitHub directory: %s", err)
+	} else if stat, err := os.Stat(result.Dst); err != nil {
+		t.Fatalf("Failed stat dst at '%s': %s", result.Dst, err)
+	} else if !stat.IsDir() {
+		t.Fatalf("Expected '%s' to be a directory", result.Dst)
+	} else if entries, err := os.ReadDir(result.Dst); err != nil {
+		t.Fatalf("Failed listing directory '%s': %s", result.Dst, err)
+	} else if len(entries) != 3 {
+		t.Fatalf("Expected dir '%s' to contain 3 items: %s", result.Dst, err)
+	} else {
+		testing_helper.AssertContents(t, filepath.Join(result.Dst, "main.tf"), basicMainTFExpectedContents)
+	}
+}
+
+func TestGitGetter_githubFileWithModeAny(t *testing.T) {
+	if !testHasGit {
+		t.Skip("git not found, skipping")
+	}
+
+	ctx := context.Background()
+	dst := testing_helper.TempDir(t)
+	defer os.RemoveAll(dst)
+
+	req := &Request{
+		Src:     "git::https://github.com/arikkfir/go-getter.git//testdata/basic/main.tf?ref=v2",
+		Dst:     dst,
+		GetMode: ModeAny,
+		Copy:    true,
+	}
+	client := Client{}
+	result, err := client.Get(ctx, req)
+	if err != nil {
+		t.Fatalf("Failed fetching GitHub file: %s", err)
+	} else if stat, err := os.Stat(result.Dst); err != nil {
+		t.Fatalf("Failed stat dst at '%s': %s", result.Dst, err)
+	} else if stat.IsDir() {
+		t.Fatalf("Expected '%s' to be a file", result.Dst)
+	} else {
+		testing_helper.AssertContents(t, result.Dst, basicMainTFExpectedContents)
+	}
+}


### PR DESCRIPTION
This currently fails for GitHub (and possibly other Git repositories) because there is an assumption in the `client.go` file that the `subDir` segment is always a directory.

However, for the URL "https://github.com/owner/repo/subdir/file.txt[](https://github.com/arikkfir)" the "subDir" variable would actually be a file (`subdir/file.txt`) and hence the client should use `copyFile` rather than `copyDir` when copying the `subDir` to the final destination.

This change fixes that to check whether the "subDir" variable is a file or a directory, and appropriately uses `copyDir` or `copyFile`. It also returns the single file in the "GetResult" object, if indeed a single file was requested.

Tests attached.

This fixes #98 