### PR TITLE
[CI-only] Add apt-get update before installing dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CODESIGN_GITHUB_TOKEN }}
       - name: Install wget & clamAV antivirus scanner
         run : |
+           sudo apt-get update
            sudo apt-get -qq install -y ca-certificates wget clamav
            wget --version
       - name: Install maldet malware scanner


### PR DESCRIPTION
This fixes https://github.com/hashicorp/go-getter/actions/runs/2348433078