### PR TITLE
Update `golang.org/x/sys` to work with `go1.18`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/stretchr/testify v1.2.2 // indirect
 	github.com/ulikunitz/xz v0.5.8
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
+	golang.org/x/sys v0.0.0-20220517195934-5e4e11fc645e // indirect
 	google.golang.org/api v0.9.0
 	gopkg.in/cheggaaa/pb.v1 v1.0.27 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,8 @@ golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0 h1:HyfiK1WMnHj5FXFXatD+Qs1A/xC2Run6RzeW1SyHxpc=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220517195934-5e4e11fc645e h1:w36l2Uw3dRan1K3TyXriXvY+6T56GNmlKGcqiQUJDfM=
+golang.org/x/sys v0.0.0-20220517195934-5e4e11fc645e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=


### PR DESCRIPTION
This PR is a follow up to https://github.com/hashicorp/go-getter/pull/360, to [fix](https://github.com/golang/go/issues/51091#issuecomment-1033334340) https://github.com/hashicorp/go-getter/runs/6498424476?check_suite_focus=true

```console
...
   ⨯ release failed after 231.07s error=failed to build for darwin_amd64_v1: exit status 2: go: downloading github.com/cheggaaa/pb v1.0.27
...
golang.org/x/sys/unix
Error: /home/runner/go/pkg/mod/golang.org/x/sys@v0.0.0-20190624142023-c5567b49c5d0/unix/zsyscall_darwin_amd64.go:28:3: //go:linkname must refer to declared function or variable
Error: /home/runner/go/pkg/mod/golang.org/x/sys@v0.0.0-20190624142023-c5567b49c5d0/unix/zsyscall_darwin_amd64.go:43:3: //go:linkname must refer to declared function or variable
Error: /home/runner/go/pkg/mod/golang.org/x/sys@v0.0.0-20190624142023-c5567b49c5d0/unix/zsyscall_darwin_amd64.go:59:3: //go:linkname must refer to declared function or variable
Error: /home/runner/go/pkg/mod/golang.org/x/sys@v0.0.0-20190624142023-c5567b49c5d0/unix/zsyscall_darwin_amd64.go:75:3: //go:linkname must refer to declared function or variable
Error: /home/runner/go/pkg/mod/golang.org/x/sys@v0.0.0-20190624142023-c5567b49c5d0/unix/zsyscall_darwin_amd64.go:90:3: //go:linkname must refer to declared function or variable
Error: /home/runner/go/pkg/mod/golang.org/x/sys@v0.0.0-20190624142023-c5567b49c5d0/unix/zsyscall_darwin_amd64.go:105:3: //go:linkname must refer to declared function or variable
Error: /home/runner/go/pkg/mod/golang.org/x/sys@v0.0.0-20190624142023-c5567b49c5d0/unix/zsyscall_darwin_amd64.go:121:3: //go:linkname must refer to declared function or variable
Error: /home/runner/go/pkg/mod/golang.org/x/sys@v0.0.0-20190624142023-c5567b49c5d0/unix/zsyscall_darwin_amd64.go:136:3: //go:linkname must refer to declared function or variable
Error: /home/runner/go/pkg/mod/golang.org/x/sys@v0.0.0-201[90](https://github.com/hashicorp/go-getter/runs/6498424476?check_suite_focus=true#step:8:91)624142023-c5567b49c5d0/unix/zsyscall_darwin_amd64.go:151:3: //go:linkname must refer to declared function or variable
Error: /home/runner/go/pkg/mod/golang.org/x/sys@v0.0.0-20190624142023-c5567b49c5d0/unix/zsyscall_darwin_amd64.go:166:3: //go:linkname must refer to declared function or variable
Error: /home/runner/go/pkg/mod/golang.org/x/sys@v0.0.0-20190624142023-c5567b49c5d0/unix/zsyscall_darwin_amd64.go:166:3: too many errors
```

For more context, `golang.org/x/sys/unix` is an indirect dependency from `github.com/cheggaaa/pb`:

```console
$ go mod why -m golang.org/x/sys
# golang.org/x/sys
github.com/hashicorp/go-getter/cmd/go-getter
github.com/cheggaaa/pb
golang.org/x/sys/unix
```
