### PR TITLE
Update default Getters with known defaults

### DIFF
--- a/get.go
+++ b/get.go
@@ -19,6 +19,7 @@ import (
 	"os/exec"
 	"regexp"
 	"syscall"
+	"time"
 
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
 )
@@ -70,7 +71,10 @@ var DefaultClient = &Client{
 
 func init() {
 	httpGetter := &HttpGetter{
-		Netrc: true,
+		Netrc:                 true,
+		XTerraformGetDisabled: true,
+		HeadFirstTimeout:      10 * time.Second,
+		ReadTimeout:           30 * time.Second,
 	}
 
 	// The order of the Getters in the list may affect the result


### PR DESCRIPTION
* By default XTerrformGet header support should be disable; clients
  needing supporting this header should overwrite the default getters
  with a custom HttpGetter

* Add default timeouts for HTTP Read Requests; including HEAD requests