### PR TITLE
 Add Timeout to SmbClientGetter to go-getter/v2

### DIFF
--- a/get_git.go
+++ b/get_git.go
@@ -26,7 +26,7 @@ import (
 type GitGetter struct {
 	Detectors []Detector
 
-	// Timeout sets a deadline which all hg CLI operations should
+	// Timeout sets a deadline which all git CLI operations should
 	// complete within. Defaults to zero which means no timeout.
 	Timeout time.Duration
 }


### PR DESCRIPTION
Allow caller to configure a command execution context with a default timeout for all smbclient CLI operations.

Related to: https://github.com/hashicorp/go-getter/pull/361