### PR TITLE
remove codesign entirely from go-getter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,15 +27,7 @@ jobs:
         uses: hashicorp/setup-signore@v1
         with:
           github-token: ${{secrets.SIGNORE_TOKEN}}
-      - name: Install hc-codesign
-        id: codesign
-        run: |
-          docker login docker.pkg.github.com -u docker -p $GITHUB_TOKEN && \
-          docker pull docker.pkg.github.com/hashicorp/hc-codesign/hc-codesign:$VERSION && \
-          echo "::set-output name=image::docker.pkg.github.com/hashicorp/hc-codesign/hc-codesign:$VERSION"
-        env:
-          VERSION: v0
-          GITHUB_TOKEN: ${{ secrets.CODESIGN_GITHUB_TOKEN }}
+    
       - name: Install wget & clamAV antivirus scanner
         run : |
            sudo apt-get update
@@ -60,7 +52,6 @@ jobs:
           args: release --skip-validate --timeout "60m"
         env:
           PGP_KEY_ID: ${{ secrets.PGP_KEY_ID }}
-          CODESIGN_IMAGE: ${{ steps.codesign.outputs.image }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
           ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,15 +8,6 @@ builds:
       - darwin_amd64
       - windows_386
       - windows_amd64
-    hooks:
-      post: |
-        docker run
-          -e ARTIFACTORY_TOKEN={{ .Env.ARTIFACTORY_TOKEN }}
-          -e ARTIFACTORY_USER={{ .Env.ARTIFACTORY_USER }}
-          -e CIRCLE_TOKEN={{ .Env.CIRCLE_TOKEN }}
-          -v {{ dir .Path }}:/workdir
-          {{ .Env.CODESIGN_IMAGE }}
-          sign -product-name={{ .ProjectName }} {{ .Name }}
     dir: ./cmd/go-getter/
     flags:
       - -trimpath


### PR DESCRIPTION
Removing codesigning from this project as users only and primarily use the library instead of the go binaries. 