### PR TITLE
Update Go-Getter test workflow to run on pull requests

### DIFF
--- a/.github/workflows/go-getter.yml
+++ b/.github/workflows/go-getter.yml
@@ -1,6 +1,13 @@
 name: go-getter
 
-on: [push]
+on: 
+  push:
+    branches:
+      - v2
+  pull_request:
+    branches:
+      - v2
+
 
 env:
   TEST_RESULTS_PATH: /tmp/test-results


### PR DESCRIPTION
Currently test for v2 run for authors who have push access to the go-getter repo. This change updates the test action to run for all open pull-request to the v2 branch, as well as on pushes to the v2 branch. 