### PR TITLE
Remove `bomb.zip` test file to stop anti-virus noise

### DIFF
--- a/decompress_zip_test.go
+++ b/decompress_zip_test.go
@@ -1,6 +1,10 @@
 package getter
 
 import (
+	"archive/zip"
+	"bytes"
+	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -132,23 +136,67 @@ func TestDecompressZipPermissions(t *testing.T) {
 }
 
 func TestDecompressZipBomb(t *testing.T) {
-	// If the zip decompression bomb protection fails, this can fill up disk space on the entire
-	// computer.
-	if os.Getenv("GO_GETTER_TEST_ZIP_BOMB") != "true" {
-		t.Skip("skipping potentially dangerous test without GO_GETTER_TEST_ZIP_BOMB=true")
+	buf := new(bytes.Buffer)
+
+	// Create a zip file inline, written to the buffer.
+	{
+		w := zip.NewWriter(buf)
+
+		var files = []struct {
+			Name, Body string
+		}{
+			{"readme.txt", "This archive contains some text files."},
+			{"gopher.txt", "Gopher names:\nGeorge\nGeoffrey\nGonzo"},
+			{"todo.txt", "Get animal handling licence.\nWrite more examples."},
+		}
+		for _, file := range files {
+			f, err := w.Create(file.Name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = f.Write([]byte(file.Body))
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		err := w.Close()
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 
-	// https://www.bamsoftware.com/hacks/zipbomb/zblg.zip
-	srcPath := filepath.Join("./testdata", "decompress-zip", "bomb.zip")
-
-	d := new(ZipDecompressor)
-	d.FileSizeLimit = 512
-
-	err := d.Decompress(t.TempDir(), srcPath, true, 0644)
-	if err == nil {
-		t.FailNow()
+	td, err := ioutil.TempDir("", "go-getter-zip")
+	if err != nil {
+		t.Fatalf("err: %s", err)
 	}
-	if !strings.Contains(err.Error(), "zip archive larger than limit: 512") {
-		t.Fatalf("unexpected error: %q", err.Error())
+
+	zipFilePath := filepath.Join(td, "input.zip")
+
+	err = os.WriteFile(zipFilePath, buf.Bytes(), 0666)
+	if err != nil {
+		t.Fatalf("err: %s", err)
 	}
+
+	t.Run("error with limit", func(t *testing.T) {
+		d := new(ZipDecompressor)
+		d.FileSizeLimit = 7 // bytes
+
+		err = d.Decompress(t.TempDir(), zipFilePath, true, 0644)
+		if err == nil {
+			t.FailNow()
+		}
+		if !strings.Contains(err.Error(), "zip archive larger than limit: 7") {
+			t.Fatalf("unexpected error: %q", err.Error())
+		}
+	})
+
+	t.Run("no error without limit", func(t *testing.T) {
+		d := new(ZipDecompressor)
+
+		err = d.Decompress(t.TempDir(), zipFilePath, true, 0644)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }


### PR DESCRIPTION
This PR aims to fix #419. The `bomb.zip` file was useful to verify the zip bomb protections worked properly, but is not required to verify out mitigations work. Including a real zip bomb lead to confusion and reports of anti-virus causing issues for users. Instead, a zip file is created inline with the test before verifying the decompression limit works.