### PR TITLE
[v2] update s3, gcs and cmd to use most recent v2 module version

### DIFF
--- a/cmd/go-getter/go.mod
+++ b/cmd/go-getter/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cheggaaa/pb v1.0.29
 	github.com/hashicorp/go-getter/gcs/v2 v2.2.0
 	github.com/hashicorp/go-getter/s3/v2 v2.2.0
-	github.com/hashicorp/go-getter/v2 v2.2.0
+	github.com/hashicorp/go-getter/v2 v2.2.1
 	github.com/mattn/go-runewidth v0.0.8 // indirect
 )
 

--- a/gcs/go.mod
+++ b/gcs/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-getter/v2 v2.2.0
+	github.com/hashicorp/go-getter/v2 v2.2.1
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect

--- a/s3/go.mod
+++ b/s3/go.mod
@@ -6,7 +6,7 @@ replace github.com/hashicorp/go-getter/v2 => ../
 
 require (
 	github.com/aws/aws-sdk-go v1.44.114
-	github.com/hashicorp/go-getter/v2 v2.2.0
+	github.com/hashicorp/go-getter/v2 v2.2.1
 )
 
 require (


### PR DESCRIPTION
- [v2] update s3, gcs and cmd to use most recent v2 module version
