### PR TITLE
Make addAuthFromNetrc ignore ENOTDIR errors

### DIFF
--- a/netrc.go
+++ b/netrc.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"os"
 	"runtime"
+	"syscall"
 
 	"github.com/bgentry/go-netrc/netrc"
 	"github.com/mitchellh/go-homedir"
@@ -38,7 +39,7 @@ func addAuthFromNetrc(u *url.URL) error {
 	// If the file is not a file, then do nothing
 	if fi, err := os.Stat(path); err != nil {
 		// File doesn't exist, do nothing
-		if os.IsNotExist(err) {
+		if serr, ok := err.(*os.PathError); ok && (os.IsNotExist(serr.Err) || serr.Err == syscall.ENOTDIR) {
 			return nil
 		}
 

--- a/netrc_test.go
+++ b/netrc_test.go
@@ -61,3 +61,43 @@ func TestAddAuthFromNetrc_hasUsername(t *testing.T) {
 		t.Fatalf("Mismatch: %q != %q", actual, expected)
 	}
 }
+
+func TestAddAuthFromNetrc_isNotExist(t *testing.T) {
+	defer tempEnv(t, "NETRC", "./testdata/netrc/_does_not_exist")()
+
+	u, err := url.Parse("http://example.com")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if err := addAuthFromNetrc(u); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// no netrc, no change:
+	expected := "http://example.com"
+	actual := u.String()
+	if expected != actual {
+		t.Fatalf("Mismatch: %q != %q", actual, expected)
+	}
+}
+
+func TestAddAuthFromNetrc_isNotADirectory(t *testing.T) {
+	defer tempEnv(t, "NETRC", "./testdata/netrc/basic/parent-not-a-dir")()
+
+	u, err := url.Parse("http://example.com")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if err := addAuthFromNetrc(u); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// no netrc, no change:
+	expected := "http://example.com"
+	actual := u.String()
+	if expected != actual {
+		t.Fatalf("Mismatch: %q != %q", actual, expected)
+	}
+}


### PR DESCRIPTION
The function already returns early if the specified 'netrc' configuration points to a non existing file, but currently returns an error if the OS reports ENOTDIR:

This will happen if the $HOME directory of the current user points to a file instead a directory - something eg. 'void linux' does for user 'nobody':

```
$ grep nobody /etc/passwd
nobody:x:99:99:Unprivileged User:/dev/null:/bin/false
```

go-getter then attempts to open `/dev/null/.netrc` which fails with ENOTDIR - something that should just be treated the same way as a non existing file (in this case)