### PR TITLE
fix(getter): race condition when SetClient is called

### DIFF
--- a/client_option.go
+++ b/client_option.go
@@ -37,7 +37,7 @@ func (c *Client) Configure(opts ...ClientOption) error {
 		c.Detectors = Detectors
 	}
 	if c.Getters == nil {
-		c.Getters = Getters
+		c.Getters = DefaultGetters()
 	}
 
 	// Set the client for each getter, so the top-level client can know

--- a/get.go
+++ b/get.go
@@ -59,12 +59,14 @@ var forcedRegexp = regexp.MustCompile(`^([A-Za-z0-9]+)::(.+)$`)
 // httpClient is the default client to be used by HttpGetters.
 var httpClient = cleanhttp.DefaultClient()
 
-func init() {
+// DefaultGetters returns the default set of getters. This is used by the
+// Client if no Getters are specified. It returns a new independent map.
+func DefaultGetters() map[string]Getter {
 	httpGetter := &HttpGetter{
 		Netrc: true,
 	}
 
-	Getters = map[string]Getter{
+	getters := map[string]Getter{
 		"file":  new(FileGetter),
 		"git":   new(GitGetter),
 		"gcs":   new(GCSGetter),
@@ -73,6 +75,11 @@ func init() {
 		"http":  httpGetter,
 		"https": httpGetter,
 	}
+	return getters
+}
+
+func init() {
+	Getters = DefaultGetters()
 }
 
 // Get downloads the directory specified by src into the folder specified by


### PR DESCRIPTION
This is a non-breaking change. This fixes an issue when Clients are created and called concurrently. 
Clients called `SetClient` on each of the `Getter`s. When no getters were provided, it modified the clients of the default getters defined in the `Getters` map. 
Since the map was mutated from multiple goroutines, it creates a race condition 'concurrent map writes'. The issue is mitigated by creating a new copy of `Getters` using `DefaultGetters()` function for every new client created. `SetClient` now modifies its own copy of the `Getter`, not the default `Getters`.

To reproduce the issue:
```bash
mkdir hello
touch hello/world
```

```go
// main.go
package main

import "github.com/hashicorp/go-getter"
import "context"
import "os"
import "sync"
import "path/filepath"

func main() {
    var wg sync.WaitGroup
    cwd, err := os.Getwd()
    if err != nil {
        panic(err)
    }
    keys := []string{"a", "b", "c"}

    for _, key := range keys {
        wg.Add(1)
        go func(key string) {
            get := &getter.Client{
                Ctx: context.Background(),
                Src: "./hello",
                Dst: filepath.Join("dest", key),
                Pwd: cwd,
                Dir: true,
            }
      err := get.Get()
            if err != nil {
                panic(err)
            }
            wg.Done()
        }(key)
    }
    wg.Wait()
}
```

```bash 
go run -race .
```
