### PR TITLE
Always remove 'filename' param from the request

### DIFF
--- a/client.go
+++ b/client.go
@@ -241,10 +241,6 @@ func (c *Client) Get() error {
 
 			// Determine if we have a custom file name
 			if v := q.Get("filename"); v != "" {
-				// Delete the query parameter if we have it.
-				q.Del("filename")
-				u.RawQuery = q.Encode()
-
 				filename = v
 			}
 
@@ -255,6 +251,10 @@ func (c *Client) Get() error {
 			dst = filepath.Join(dst, filename)
 		}
 	}
+
+	// Delete the query parameter if we have it. It won't be used from now on.
+	q.Del("filename")
+	u.RawQuery = q.Encode()
 
 	// If we're not downloading a directory, then just download the file
 	// and return.


### PR DESCRIPTION
This is a fix which always removes the `filename` magic parameter from the download request. See the issue for more details: #471


Resolves #471
