### PR TITLE
Escape User Passed Git Options

### DIFF
--- a/get_git.go
+++ b/get_git.go
@@ -200,7 +200,7 @@ func (g *GitGetter) clone(ctx context.Context, dst, sshKeyFile string, u *url.UR
 		args = append(args, "--depth", strconv.Itoa(depth))
 		args = append(args, "--branch", ref)
 	}
-	args = append(args, u.String(), dst)
+	args = append(args, "--", u.String(), dst)
 
 	cmd := exec.CommandContext(ctx, "git", args...)
 	setupGitEnv(cmd, sshKeyFile)
@@ -289,7 +289,7 @@ func findDefaultBranch(ctx context.Context, dst string) string {
 // default branch. "master" is returned if no HEAD symref exists.
 func findRemoteDefaultBranch(ctx context.Context, u *url.URL) string {
 	var stdoutbuf bytes.Buffer
-	cmd := exec.CommandContext(ctx, "git", "ls-remote", "--symref", u.String(), "HEAD")
+	cmd := exec.CommandContext(ctx, "git", "ls-remote", "--symref", "--", u.String(), "HEAD")
 	cmd.Stdout = &stdoutbuf
 	err := cmd.Run()
 	matches := lsRemoteSymRefRegexp.FindStringSubmatch(stdoutbuf.String())

--- a/get_git_test.go
+++ b/get_git_test.go
@@ -836,6 +836,36 @@ func TestGitGetter_subdirectory(t *testing.T) {
 	}
 }
 
+func TestGitGetter_BadRemoteUrl(t *testing.T) {
+
+	if !testHasGit {
+		t.Log("git not found, skipping")
+		t.Skip()
+	}
+
+	g := new(GitGetter)
+	dst := tempDir(t)
+
+	// try an option that exists
+	badUrl := "--no-refs"
+
+	u, err := url.Parse(badUrl)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = g.Get(dst, u)
+	if err == nil {
+		t.Fatalf("get succeeded; want error")
+	}
+
+	got := err.Error()
+	want := `unknown option`
+	if !strings.Contains(got, want) {
+		t.Fatalf("wrong error\ngot:  %s\nwant: %q", got, want)
+	}
+}
+
 // gitRepo is a helper struct which controls a single temp git repo.
 type gitRepo struct {
 	t   *testing.T


### PR DESCRIPTION
Escapes user-provided strings that may be interpreted as valid Git options.