### PR TITLE
Update cmd/go-getter to use that latest versions of go-getter/v2

### DIFF
--- a/cmd/go-getter/go.mod
+++ b/cmd/go-getter/go.mod
@@ -10,8 +10,8 @@ replace (
 
 require (
 	github.com/cheggaaa/pb v1.0.29
-	github.com/hashicorp/go-getter/gcs/v2 v2.2.0
-	github.com/hashicorp/go-getter/s3/v2 v2.2.0
+	github.com/hashicorp/go-getter/gcs/v2 v2.2.2
+	github.com/hashicorp/go-getter/s3/v2 v2.2.2
 	github.com/hashicorp/go-getter/v2 v2.2.2
 	github.com/mattn/go-runewidth v0.0.8 // indirect
 )


### PR DESCRIPTION
 [v2] update cmd to use go-getter/v2, s3/v2, and gcs/v2 v2.2.2
