### PR TITLE
feat: Access public S3 bucket by setting anonymous credentials when no key or token given

### DIFF
--- a/get_s3.go
+++ b/get_s3.go
@@ -319,6 +319,8 @@ func (g *S3Getter) parseUrl(u *url.URL) (region, bucket, path, version string, c
 			u.Query().Get("aws_access_key_secret"),
 			u.Query().Get("aws_access_token"),
 		)
+	} else {
+		creds = credentials.AnonymousCredentials
 	}
 
 	return


### PR DESCRIPTION
Public s3 buckets are right now inaccessible because one of aws key or token is mandatory in url.

The aws sdk handle this by providing a special global `credentials.AnonymousCredentials` variable, which is used in a strict comparison to provided credentials on requests.

This pr just assume that when no key or token is passed by url, the user want anonymous access, and can requests on public buckets.