### PR TITLE
Backport fix from https://github.com/hashicorp/go-getter/pull/497 to v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile to create a go-getter container with smbclient dependency that is used by the get_smb.go tests
-FROM golang:1.15
+FROM golang:1.19.13
 
 COPY . /go-getter
 WORKDIR /go-getter

--- a/get_git.go
+++ b/get_git.go
@@ -122,7 +122,7 @@ func (g *GitGetter) Get(ctx context.Context, req *Request) error {
 		return err
 	}
 	if err == nil {
-		err = g.update(ctx, req.Dst, sshKeyFile, ref, depth)
+		err = g.update(ctx, req.Dst, sshKeyFile, ref, req.URL(), depth)
 	} else {
 		err = g.clone(ctx, sshKeyFile, depth, req)
 	}
@@ -193,28 +193,63 @@ func (g *GitGetter) clone(ctx context.Context, sshKeyFile string, depth int, req
 	return getRunCommand(cmd)
 }
 
-func (g *GitGetter) update(ctx context.Context, dst, sshKeyFile, ref string, depth int) error {
-	// Determine if we're a branch. If we're NOT a branch, then we just
-	// switch to master prior to checking out
-	cmd := exec.CommandContext(ctx, "git", "show-ref", "-q", "--verify", "refs/heads/"+ref)
-	cmd.Dir = dst
+func (g *GitGetter) update(ctx context.Context, dst, sshKeyFile, ref string, u *url.URL, depth int) error {
+	// Remove all variations of .git directories
+	err := removeCaseInsensitiveGitDirectory(dst)
+	if err != nil {
+		return err
 
-	if getRunCommand(cmd) != nil {
-		// Not a branch, switch to default branch. This will also catch
-		// non-existent branches, in which case we want to switch to default
-		// and then checkout the proper branch later.
-		ref = findDefaultBranch(ctx, dst)
 	}
 
-	// We have to be on a branch to pull
+	// Initialize the git repository
+	cmd := exec.CommandContext(ctx, "git", "init")
+	cmd.Dir = dst
+	err = getRunCommand(cmd)
+	if err != nil {
+		return err
+	}
+
+	// Add the git remote
+	cmd = exec.CommandContext(ctx, "git", "remote", "add", "origin", "--", u.String())
+	cmd.Dir = dst
+	err = getRunCommand(cmd)
+	if err != nil {
+		return err
+	}
+
+	// Fetch the remote ref
+	cmd = exec.CommandContext(ctx, "git", "fetch", "--tags")
+	cmd.Dir = dst
+	err = getRunCommand(cmd)
+	if err != nil {
+		return err
+	}
+
+	// Fetch the remote ref
+	cmd = exec.CommandContext(ctx, "git", "fetch", "origin", "--", ref)
+	cmd.Dir = dst
+	err = getRunCommand(cmd)
+	if err != nil {
+		return err
+	}
+
+	// Reset the branch to the fetched ref
+	cmd = exec.CommandContext(ctx, "git", "reset", "--hard", "FETCH_HEAD")
+	cmd.Dir = dst
+	err = getRunCommand(cmd)
+	if err != nil {
+		return err
+	}
+
+	// Checkout ref branch
 	if err := g.checkout(ctx, dst, ref); err != nil {
 		return err
 	}
 
 	if depth > 0 {
-		cmd = exec.CommandContext(ctx, "git", "pull", "--depth", strconv.Itoa(depth), "--ff-only")
+		cmd = exec.CommandContext(ctx, "git", "pull", "origin", "--depth", strconv.Itoa(depth), "--ff-only", "--", ref)
 	} else {
-		cmd = exec.CommandContext(ctx, "git", "pull", "--ff-only")
+		cmd = exec.CommandContext(ctx, "git", "pull", "origin", "--ff-only", "--", ref)
 	}
 
 	cmd.Dir = dst
@@ -324,6 +359,28 @@ func checkGitVersion(ctx context.Context, min string) error {
 	}
 
 	return nil
+}
+
+// removeCaseInsensitiveGitDirectory removes all .git directory variations
+func removeCaseInsensitiveGitDirectory(dst string) error {
+	files, err := os.ReadDir(dst)
+	if err != nil {
+		return fmt.Errorf("Failed to read the destination directory %s during git update", dst)
+
+	}
+	for _, f := range files {
+		if strings.EqualFold(f.Name(), ".git") && f.IsDir() {
+			err := os.RemoveAll(filepath.Join(dst, f.Name()))
+			if err != nil {
+				return fmt.Errorf("Failed to remove the .git directory in the destination directory %s during git update", dst)
+
+			}
+
+		}
+
+	}
+	return nil
+
 }
 
 func (g *GitGetter) Detect(req *Request) (bool, error) {


### PR DESCRIPTION
Recreate git config during update to prevent git config alteration

Related to: #497 