### PR TITLE
fix: Avoid panic when s3 URL is invalid

### DIFF
--- a/get_s3.go
+++ b/get_s3.go
@@ -276,7 +276,7 @@ func (g *S3Getter) parseUrl(u *url.URL) (region, bucket, path, version string, c
 			path = pathParts[2]
 		// vhost-style, dash region indication
 		case 4:
-			// Parse the region out of the first part of the host
+			// Parse the region out of the second part of the host
 			region = strings.TrimPrefix(strings.TrimPrefix(hostParts[1], "s3-"), "s3")
 			if region == "" {
 				err = fmt.Errorf("URL is not a valid S3 URL")
@@ -293,7 +293,7 @@ func (g *S3Getter) parseUrl(u *url.URL) (region, bucket, path, version string, c
 		case 5:
 			region = hostParts[2]
 			pathParts := strings.SplitN(u.Path, "/", 2)
-			if len(pathParts) < 3 {
+			if len(pathParts) < 2 {
 				err = fmt.Errorf("URL is not a valid S3 URL")
 				return
 			}

--- a/get_s3.go
+++ b/get_s3.go
@@ -268,6 +268,10 @@ func (g *S3Getter) parseUrl(u *url.URL) (region, bucket, path, version string, c
 				region = "us-east-1"
 			}
 			pathParts := strings.SplitN(u.Path, "/", 3)
+			if len(pathParts) < 3 {
+				err = fmt.Errorf("URL is not a valid S3 URL")
+				return
+			}
 			bucket = pathParts[1]
 			path = pathParts[2]
 		// vhost-style, dash region indication
@@ -279,12 +283,20 @@ func (g *S3Getter) parseUrl(u *url.URL) (region, bucket, path, version string, c
 				return
 			}
 			pathParts := strings.SplitN(u.Path, "/", 2)
+			if len(pathParts) < 2 {
+				err = fmt.Errorf("URL is not a valid S3 URL")
+				return
+			}
 			bucket = hostParts[0]
 			path = pathParts[1]
 		//vhost-style, dot region indication
 		case 5:
 			region = hostParts[2]
 			pathParts := strings.SplitN(u.Path, "/", 2)
+			if len(pathParts) < 3 {
+				err = fmt.Errorf("URL is not a valid S3 URL")
+				return
+			}
 			bucket = hostParts[0]
 			path = pathParts[1]
 


### PR DESCRIPTION
Gracefully handle when S3 URLs have an unexpected number of path segments.

Currently we expect `s3.amazonaws.com/bucket/path`, but something like `s3.amazonaws.com/bucket` will cause a panic, e.g.

```
panic: runtime error: index out of range [2] with length 2

github.com/hashicorp/go-getter.(*S3Getter).parseUrl(,)
    /go/pkg/mod/github.com/hashicorp/go-getter@v1.7.5/get_s3.go:272
github.com/hashicorp/go-getter.(*S3Getter).Get(, {,},)
    /go/pkg/mod/git...
```