### PR TITLE
Clean up git repo on disk when the ref checkout fails

### DIFF
--- a/get_git.go
+++ b/get_git.go
@@ -223,7 +223,12 @@ func (g *GitGetter) clone(ctx context.Context, dst, sshKeyFile string, u *url.UR
 		// If we didn't add --depth and --branch above then we will now be
 		// on the remote repository's default branch, rather than the selected
 		// ref, so we'll need to fix that before we return.
-		return g.checkout(ctx, dst, originalRef)
+		err := g.checkout(ctx, dst, originalRef)
+		if err != nil {
+			// Clean up git repository on disk
+			_ = os.RemoveAll(dst)
+			return err
+		}
 	}
 	return nil
 }

--- a/get_git_test.go
+++ b/get_git_test.go
@@ -984,6 +984,38 @@ func TestGitGetter_BadGitDirName(t *testing.T) {
 	}
 }
 
+func TestGitGetter_BadRef(t *testing.T) {
+	if !testHasGit {
+		t.Log("git not found, skipping")
+		t.Skip()
+	}
+
+	ctx := context.Background()
+	g := new(GitGetter)
+	dst := tempDir(t)
+
+	url, err := url.Parse("https://github.com/hashicorp/go-getter")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = os.Stat(dst)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf(err.Error())
+	}
+
+	// Clone a repository with non-existent ref
+	err = g.clone(ctx, dst, "", url, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 0)
+	if err == nil {
+		t.Fatalf(err.Error())
+	}
+
+	// Expect that the dst was cleaned up after failed ref checkout
+	if _, err := os.Stat(dst); !os.IsNotExist(err) {
+		t.Fatalf("cloned repository still exists after bad ref checkout")
+	}
+}
+
 // gitRepo is a helper struct which controls a single temp git repo.
 type gitRepo struct {
 	t   *testing.T


### PR DESCRIPTION
If the `ref` checkout during a call to `clone()` fails, this ensures the cloned repo on disk will get cleaned up.