### PR TITLE
Updating arguments in github release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
         with:
           version: latest
-          args: release --skip-validate --timeout "60m"
+          args: release --skip=validate --timeout "60m"
         env:
           PGP_KEY_ID: ${{ secrets.PGP_KEY_ID }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The latest version of goreleaser has deprecated the used of _--skip-validate_ flag. So the flag is updated according to the latest version.