### PR TITLE
Updating .goreleaser.yml file with valid version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+version: 2
+
 env:
   - GOPRIVATE=github.com/hashicorp
 
@@ -49,4 +51,4 @@ signs:
     artifacts: checksum
 
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
The latest version of goreleaser needs to use the latest version of .goreleaser.yml . Hence updating the same in this PR.

References:
https://goreleaser.com/errors/version/
https://goreleaser.com/deprecations/#changelogskip