### PR TITLE
Speed up XZ decompression by 5x with bufio wrapper

### DIFF
--- a/decompress_txz.go
+++ b/decompress_txz.go
@@ -4,6 +4,7 @@
 package getter
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -45,7 +46,7 @@ func (d *TarXzDecompressor) Decompress(dst, src string, dir bool, umask os.FileM
 	defer f.Close()
 
 	// xz compression is second
-	txzR, err := xz.NewReader(f)
+	txzR, err := xz.NewReader(bufio.NewReader(f))
 	if err != nil {
 		return fmt.Errorf("Error opening an xz reader for %s: %s", src, err)
 	}

--- a/decompress_xz.go
+++ b/decompress_xz.go
@@ -4,6 +4,7 @@
 package getter
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -39,7 +40,7 @@ func (d *XzDecompressor) Decompress(dst, src string, dir bool, umask os.FileMode
 	defer f.Close()
 
 	// xz compression is second
-	xzR, err := xz.NewReader(f)
+	xzR, err := xz.NewReader(bufio.NewReader(f))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Nomad was taking over 7.5 seconds just to extract an 11MB tar.xz archive for our use case.
Investigation led to XZ library which performs poorly without buffered I/O (https://github.com/ulikunitz/xz/issues/23).

Decompression performance can be improved dramatically by introducing buffered I/O as suggested in the case.

Benchmark results (using hyperfine with identical test files served from a local `python3 -m http.server 8888` web server):

Before:
```
./go-getter http://localhost:8888/test.tar.xz tmp-xz
Time (mean ± σ): 7.721s ± 0.019s [User: 3.541s, System: 4.225s]
Range (min … max): 7.685s … 7.749s (10 runs)
```

After:
```
./go-getter http://localhost:8888/test.tar.xz tmp-xz
Time (mean ± σ): 1.429s ± 0.025s [User: 1.378s, System: 0.061s]
Range (min … max): 1.411s … 1.495s (10 runs)
```

This represents a 5.4x speedup and should significantly improve performance when working with XZ-compressed artifacts.