### PR TITLE
Fix CI Workflow

### DIFF
--- a/.github/workflows/go-getter.yml
+++ b/.github/workflows/go-getter.yml
@@ -81,7 +81,7 @@ jobs:
       
       # Save coverage report parts
       - name: Upload and save artifacts
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
         with:
           name: linux test results
           path: linux_cov.part
@@ -150,7 +150,7 @@ jobs:
       
       # Save coverage report parts
       - name: Upload and save artifacts
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
         with:
           name: windows test results
           path: win_cov.part

--- a/.github/workflows/go-getter.yml
+++ b/.github/workflows/go-getter.yml
@@ -31,7 +31,7 @@ jobs:
           mkdir -p ${{ env.TEST_RESULTS_PATH }}
   
       - name: Setup cache for go modules
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: |
             ~/.cache/go-build
@@ -109,7 +109,7 @@ jobs:
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
 
       - name: Setup cache for go modules
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: |
             ~\AppData\Local\go-build

--- a/.github/workflows/go-getter.yml
+++ b/.github/workflows/go-getter.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Upload and save artifacts
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
         with:
-          name: linux test results
+          name: linux-test-results-${{ matrix.go-version }}
           path: linux_cov.part
 
   windows-tests:
@@ -152,5 +152,5 @@ jobs:
       - name: Upload and save artifacts
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
         with:
-          name: windows test results
+          name: windows-test-results-${{ matrix.go-version }}
           path: win_cov.part


### PR DESCRIPTION
- Updated the actions/cache and actions/artifact-upload versions in the Workflow file.
- Updated artifact names by adding golang version number as suffix.