### PR TITLE
test: Remove use of "mitchellh/go-testing-interface" for stdlib

### DIFF
--- a/decompress_testing.go
+++ b/decompress_testing.go
@@ -14,9 +14,8 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"testing"
 	"time"
-
-	"github.com/mitchellh/go-testing-interface"
 )
 
 // TestDecompressCase is a single test case for testing decompressors
@@ -30,7 +29,7 @@ type TestDecompressCase struct {
 }
 
 // TestDecompressor is a helper function for testing generic decompressors.
-func TestDecompressor(t testing.T, d Decompressor, cases []TestDecompressCase) {
+func TestDecompressor(t testing.TB, d Decompressor, cases []TestDecompressCase) {
 	t.Helper()
 
 	for _, tc := range cases {
@@ -83,7 +82,7 @@ func TestDecompressor(t testing.T, d Decompressor, cases []TestDecompressCase) {
 							t.Fatalf("err %s: expected mtime '%s' for %s, got '%s'", tc.Input, expected.String(), dst, actual.String())
 						}
 					} else if actual.Unix() <= 0 {
-						t.Fatalf("err %s: expected mtime to be > 0, got '%s'", actual.String())
+						t.Fatalf("err %s: expected mtime to be > 0, got '%s'", tc.Input, actual.String())
 					}
 				}
 
@@ -118,7 +117,7 @@ func TestDecompressor(t testing.T, d Decompressor, cases []TestDecompressCase) {
 							t.Fatalf("err %s: expected mtime '%s' for %s, got '%s'", tc.Input, expected.String(), path, actual.String())
 						}
 					} else if actual.Unix() < 0 {
-						t.Fatalf("err %s: expected mtime to be > 0, got '%s'", actual.String())
+						t.Fatalf("err %s: expected mtime to be > 0, got '%s'", tc.Input, actual.String())
 					}
 
 				}
@@ -127,7 +126,7 @@ func TestDecompressor(t testing.T, d Decompressor, cases []TestDecompressCase) {
 	}
 }
 
-func testListDir(t testing.T, path string) []string {
+func testListDir(t testing.TB, path string) []string {
 	var result []string
 	err := filepath.Walk(path, func(sub string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -156,7 +155,7 @@ func testListDir(t testing.T, path string) []string {
 	return result
 }
 
-func testMD5(t testing.T, path string) string {
+func testMD5(t testing.TB, path string) string {
 	f, err := os.Open(path)
 	if err != nil {
 		t.Fatalf("err: %s", err)

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/mattn/go-runewidth v0.0.4 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/mitchellh/go-testing-interface v1.14.1
 	github.com/ulikunitz/xz v0.5.10
 	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/oauth2 v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -843,8 +843,6 @@ github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8/go.mod h1:mC1jAcs
 github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3/go.mod h1:RagcQ7I8IeTMnF8JTXieKnO4Z6JCsikNEzj0DwauVzE=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
-github.com/mitchellh/go-testing-interface v1.14.1 h1:jrgshOhYAUVNMAJiKbEu7EqAwgJJ2JqpQmpLJOu07cU=
-github.com/mitchellh/go-testing-interface v1.14.1/go.mod h1:gfgS7OtZj6MA4U1UrDRp04twqAjfvlZyCfX3sDjEym8=
 github.com/phpdave11/gofpdf v1.4.2/go.mod h1:zpO6xFn9yxo3YLyMvW8HcKWVdbNqgIfOOp2dXMnm1mY=
 github.com/phpdave11/gofpdi v1.0.12/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
 github.com/phpdave11/gofpdi v1.0.13/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=


### PR DESCRIPTION
The stdlib testing package now includes this interface, so we can remove our dependency on the external library.

Related: https://github.com/hashicorp/nomad/pull/25640