### PR TITLE
Publish arm binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,21 +7,16 @@ env:
   - GOPRIVATE=github.com/hashicorp
 
 builds:
-  - id: signable
-    mod_timestamp: '{{ .CommitTimestamp }}'
-    targets:
-      - darwin_amd64
-      - windows_386
-      - windows_amd64
-    dir: ./cmd/go-getter/
-    flags:
-      - -trimpath
-    ldflags:
-      - -X main.GitCommit={{ .Commit }}
   - mod_timestamp: '{{ .CommitTimestamp }}'
     targets:
+      - darwin_amd64
+      - darwin_arm64
       - linux_386
       - linux_amd64
+      - linux_arm64
+      - windows_386
+      - windows_arm64
+      - windows_amd64
     dir: ./cmd/go-getter/
     flags:
       - -trimpath


### PR DESCRIPTION
This updates goreleaser to also publish ARM and AMD binaries for target platforms.

There were two build targets that were identical, so I merged them.