### PR TITLE
fetch remote ref during update on git repository

### DIFF
--- a/get_git.go
+++ b/get_git.go
@@ -267,6 +267,11 @@ func (g *GitGetter) update(ctx context.Context, dst, sshKeyFile string, u *url.U
 		return err
 	}
 
+	// If the ref is empty, we need to find the default branch, otherwise fetch command will fail
+	if ref == "" {
+		ref = findRemoteDefaultBranch(ctx, u)
+	}
+
 	// Fetch the remote ref
 	cmd = exec.CommandContext(ctx, "git", "fetch", "origin", "--", ref)
 	cmd.Dir = dst


### PR DESCRIPTION
It seems `getter.Get` during `update` does not use the same ref as in `clone` command.

The repetitive call of `.Get` on url without specified **ref**

```go
        src := "git::https://github.com/hashicorp/go-getter"
        dest := "/tmp/test"

	err := getter.Get(dest, src)
	if err != nil {
		log.Fatalf("get repo: %v", err)
	}
```

fails with the following error:

```
/usr/bin/git exited with 128: fatal: empty string is not a valid pathspec. please use . instead if you meant to match all paths
```

Is this by design or should the library match `clone` behaviour?
