### PR TITLE
fix: #538 http file download skipped if headResp.ContentLength is 0

### DIFF
--- a/get_http.go
+++ b/get_http.go
@@ -443,7 +443,7 @@ func (g *HttpGetter) GetFile(dst string, src *url.URL) error {
 			if headResp.StatusCode == 200 {
 				// If the HEAD request succeeded, then attempt to set the range
 				// query if we can.
-				if headResp.Header.Get("Accept-Ranges") == "bytes" && headResp.ContentLength >= 0 {
+				if headResp.Header.Get("Accept-Ranges") == "bytes" && headResp.ContentLength > 0 {
 					if fi, err := f.Stat(); err == nil {
 						if _, err = f.Seek(0, io.SeekEnd); err == nil {
 							currentFileSize = fi.Size()


### PR DESCRIPTION
We have an issue with terraform not downloading our private modules from gitlab when we do it from a location that uses the azure entra application proxy in between.

After investigation it seems that the response.contentlength is 0 in the header and the download gets skipped
it presumes the file already exists and continues to try to extract the empty archive

https://github.com/hashicorp/go-getter/blob/e70221100018573cdc74411c95c19b2a372f6728/get_http.go#L446

changing the condition from `headResp.ContentLength >= 0` to 
`headResp.ContentLength > 0 ` resolves the issue for us

seems that azure proxy doesnt set the content length correctly

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

