### PR TITLE
fix: go-getter subdir paths

### DIFF
--- a/copy_dir.go
+++ b/copy_dir.go
@@ -31,7 +31,8 @@ func copyDir(ctx context.Context, dst string, src string, ignoreDot bool, disabl
 
 	// Check if the resolved path tries to escape upward from the original
 	if disableSymlinks {
-		if rel, err := filepath.Rel(filepath.Dir(src), resolved); err != nil || filepath.IsAbs(rel) || containsDotDot(rel) {
+		rel, err := filepath.Rel(filepath.Dir(src), resolved)
+		if err != nil || filepath.IsAbs(rel) || containsDotDot(rel) {
 			return ErrSymlinkCopy
 		}
 	}

--- a/copy_dir.go
+++ b/copy_dir.go
@@ -30,8 +30,10 @@ func copyDir(ctx context.Context, dst string, src string, ignoreDot bool, disabl
 	}
 
 	// Check if the resolved path tries to escape upward from the original
-	if rel, err := filepath.Rel(filepath.Dir(src), resolved); err != nil || filepath.IsAbs(rel) || containsDotDot(rel) {
-		return fmt.Errorf("symlink path traversal detected")
+	if disableSymlinks && src != resolved {
+		if rel, err := filepath.Rel(filepath.Dir(src), resolved); err != nil || filepath.IsAbs(rel) || containsDotDot(rel) {
+			return fmt.Errorf("symlink path traversal detected")
+		}
 	}
 
 	walkFn := func(path string, info os.FileInfo, err error) error {

--- a/copy_dir.go
+++ b/copy_dir.go
@@ -30,9 +30,9 @@ func copyDir(ctx context.Context, dst string, src string, ignoreDot bool, disabl
 	}
 
 	// Check if the resolved path tries to escape upward from the original
-	if disableSymlinks && src != resolved {
+	if disableSymlinks {
 		if rel, err := filepath.Rel(filepath.Dir(src), resolved); err != nil || filepath.IsAbs(rel) || containsDotDot(rel) {
-			return fmt.Errorf("symlink path traversal detected")
+			return ErrSymlinkCopy
 		}
 	}
 

--- a/get_git.go
+++ b/get_git.go
@@ -49,6 +49,8 @@ func (g *GitGetter) Get(dst string, u *url.URL) error {
 		defer cancel()
 	}
 
+	g.client.DisableSymlinks = true
+
 	if _, err := exec.LookPath("git"); err != nil {
 		return fmt.Errorf("git must be available and on the PATH")
 	}

--- a/get_git.go
+++ b/get_git.go
@@ -49,8 +49,6 @@ func (g *GitGetter) Get(dst string, u *url.URL) error {
 		defer cancel()
 	}
 
-	g.client.DisableSymlinks = true
-
 	if _, err := exec.LookPath("git"); err != nil {
 		return fmt.Errorf("git must be available and on the PATH")
 	}
@@ -304,6 +302,9 @@ func (g *GitGetter) update(ctx context.Context, dst, sshKeyFile string, u *url.U
 
 // fetchSubmodules downloads any configured submodules recursively.
 func (g *GitGetter) fetchSubmodules(ctx context.Context, dst, sshKeyFile string, depth int) error {
+	if g.client != nil {
+		g.client.DisableSymlinks = true
+	}
 	args := []string{"submodule", "update", "--init", "--recursive"}
 	if depth > 0 {
 		args = append(args, "--depth", strconv.Itoa(depth))

--- a/get_git_test.go
+++ b/get_git_test.go
@@ -851,6 +851,10 @@ func TestGitGetter_subdirectory_malicious_symlink(t *testing.T) {
 		t.Fatalf("expected /etc/passwd to not exist in destination")
 	}
 
+	if !errors.Is(err, ErrSymlinkCopy) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
 }
 
 func TestGitGetter_subdirectory(t *testing.T) {

--- a/get_git_test.go
+++ b/get_git_test.go
@@ -807,6 +807,11 @@ func TestGitGetter_subdirectory_malicious_symlink(t *testing.T) {
 		t.Skip("git not found, skipping")
 	}
 
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows since the test requires sh")
+		return
+	}
+
 	g := new(GitGetter)
 	dst := tempDir(t)
 


### PR DESCRIPTION
[SECVULN-11445](https://hashicorp.atlassian.net/browse/SECVULN-11445)

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.


[SECVULN-11445]: https://hashicorp.atlassian.net/browse/SECVULN-11445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ