### PR TITLE
backport of PR 540 to v2

### DIFF
--- a/client.go
+++ b/client.go
@@ -24,6 +24,9 @@ var ErrSymlinkCopy = errors.New("copying of symlinks has been disabled")
 // Using a client directly allows more fine-grained control over how downloading
 // is done, as well as customizing the protocols supported.
 type Client struct {
+	// Ctx for cancellation
+	Ctx context.Context
+
 	// Decompressors is the map of decompressors supported by this client.
 	// If this is nil, then the default value is the Decompressors global.
 	Decompressors map[string]Decompressor

--- a/client_option.go
+++ b/client_option.go
@@ -31,5 +31,12 @@ func (c *Client) configure() error {
 	if c.Getters == nil {
 		c.Getters = Getters
 	}
+
+	// Set the client for each getter, so the top-level client can know
+	// the getter-specific client functions or progress tracking.
+	for _, getter := range c.Getters {
+		getter.SetClient(c)
+	}
+
 	return nil
 }

--- a/get.go
+++ b/get.go
@@ -51,6 +51,11 @@ type Getter interface {
 	// with a valid scheme for the Getter, and also check if the
 	// current Getter is the forced one and return true if that's the case.
 	Detect(*Request) (bool, error)
+
+	// SetClient allows a getter to know it's client
+	// in order to access client's Get functions or
+	// progress tracking.
+	SetClient(*Client)
 }
 
 // Getters is the mapping of scheme to the Getter implementation that will

--- a/get_base.go
+++ b/get_base.go
@@ -1,0 +1,23 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package getter
+
+import "context"
+
+// getter is our base getter; it regroups
+// fields all getters have in common.
+type getter struct {
+	client *Client
+}
+
+func (g *getter) SetClient(c *Client) { g.client = c }
+
+// Context tries to returns the Contex from the getter's
+// client. otherwise context.Background() is returned.
+func (g *getter) Context() context.Context {
+	if g == nil || g.client == nil {
+		return context.Background()
+	}
+	return g.client.Ctx
+}

--- a/get_file.go
+++ b/get_file.go
@@ -11,7 +11,9 @@ import (
 
 // FileGetter is a Getter implementation that will download a module from
 // a file scheme.
-type FileGetter struct{}
+type FileGetter struct {
+	getter
+}
 
 func (g *FileGetter) Mode(ctx context.Context, u *url.URL) (Mode, error) {
 	path := u.Path

--- a/get_git.go
+++ b/get_git.go
@@ -24,6 +24,7 @@ import (
 // GitGetter is a Getter implementation that will download a module from
 // a git repository.
 type GitGetter struct {
+	getter
 	Detectors []Detector
 
 	// Timeout sets a deadline which all git CLI operations should
@@ -259,6 +260,9 @@ func (g *GitGetter) update(ctx context.Context, dst, sshKeyFile, ref string, u *
 
 // fetchSubmodules downloads any configured submodules recursively.
 func (g *GitGetter) fetchSubmodules(ctx context.Context, dst, sshKeyFile string, depth int) error {
+	if g.client != nil {
+		g.client.DisableSymlinks = true
+	}
 	args := []string{"submodule", "update", "--init", "--recursive"}
 	if depth > 0 {
 		args = append(args, "--depth", strconv.Itoa(depth))

--- a/get_hg.go
+++ b/get_hg.go
@@ -17,6 +17,7 @@ import (
 // HgGetter is a Getter implementation that will download a module from
 // a Mercurial repository.
 type HgGetter struct {
+	getter
 
 	// Timeout sets a deadline which all hg CLI operations should
 	// complete within. Defaults to zero which means no timeout.

--- a/get_http.go
+++ b/get_http.go
@@ -38,6 +38,7 @@ import (
 // formed URL. The shorthand syntax of "github.com/foo/bar" or relative
 // paths are not allowed.
 type HttpGetter struct {
+	getter
 
 	// Netrc, if true, will lookup and use auth information found
 	// in the user's netrc file if available.

--- a/get_smb_mount.go
+++ b/get_smb_mount.go
@@ -13,7 +13,9 @@ import (
 // For Unix and MacOS users, the Getter will look for usual system specific mount paths such as:
 // /Volumes/ for MacOS
 // /run/user/1000/gvfs/smb-share:server=<hostIP>,share=<path> for Unix
-type SmbMountGetter struct{}
+type SmbMountGetter struct {
+	getter
+}
 
 func (g *SmbMountGetter) Mode(ctx context.Context, u *url.URL) (Mode, error) {
 	if u.Host == "" || u.Path == "" {

--- a/get_smbclient.go
+++ b/get_smbclient.go
@@ -17,6 +17,7 @@ import (
 // SmbClientGetter is a Getter implementation that will download a module from
 // a shared folder using smbclient cli.
 type SmbClientGetter struct {
+	getter
 
 	// Timeout in seconds sets a deadline which all smb client CLI operations should
 	// complete within. Defaults to zero which means to use the default client timeout of 20 seconds.

--- a/get_test.go
+++ b/get_test.go
@@ -605,6 +605,9 @@ func TestGetFile_checksum_from_file(t *testing.T) {
 	}
 }
 
+// SetClient implements the Getter interface for MockGetter.
+func (m *MockGetter) SetClient(c *Client) {}
+
 func TestGetFile_checksumURL(t *testing.T) {
 	ctx := context.Background()
 

--- a/module_test.go
+++ b/module_test.go
@@ -1,10 +1,13 @@
 package getter
 
 import (
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"path/filepath"
+	"testing"
 
 	urlhelper "github.com/hashicorp/go-getter/v2/helper/url"
 )
@@ -42,4 +45,16 @@ func testModuleURL(n string) *url.URL {
 	}
 
 	return u
+}
+
+func tempDir(t *testing.T) string {
+	dir, err := ioutil.TempDir("", "tf")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	return dir
 }


### PR DESCRIPTION
Backport of https://github.com/hashicorp/go-getter/pull/540.
There were some context and clients missing in structs which I added in v2.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
