### PR TITLE
Ensure temporary directory symlinks do not cause errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 
 	urlhelper "github.com/hashicorp/go-getter/helper/url"
-	safetemp "github.com/hashicorp/go-safetemp"
 )
 
 // ErrSymlinkCopy means that a copy of a symlink was encountered on a request with DisableSymlinks enabled.
@@ -143,7 +142,7 @@ func (c *Client) Get() error {
 			subDir = subDir[1:]
 		}
 
-		td, tdcloser, err := safetemp.Dir("", "getter")
+		td, tdcloser, err := mkdirTemp("", "getter")
 		if err != nil {
 			return err
 		}

--- a/get_git.go
+++ b/get_git.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	urlhelper "github.com/hashicorp/go-getter/helper/url"
-	safetemp "github.com/hashicorp/go-safetemp"
 	version "github.com/hashicorp/go-version"
 )
 
@@ -148,7 +147,7 @@ func (g *GitGetter) Get(dst string, u *url.URL) error {
 // GetFile for Git doesn't support updating at this time. It will download
 // the file every time.
 func (g *GitGetter) GetFile(dst string, u *url.URL) error {
-	td, tdcloser, err := safetemp.Dir("", "getter")
+	td, tdcloser, err := mkdirTemp("", "getter")
 	if err != nil {
 		return err
 	}

--- a/get_hg.go
+++ b/get_hg.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	urlhelper "github.com/hashicorp/go-getter/helper/url"
-	safetemp "github.com/hashicorp/go-safetemp"
 )
 
 // HgGetter is a Getter implementation that will download a module from
@@ -85,7 +84,7 @@ func (g *HgGetter) Get(dst string, u *url.URL) error {
 func (g *HgGetter) GetFile(dst string, u *url.URL) error {
 	// Create a temporary directory to store the full source. This has to be
 	// a non-existent directory.
-	td, tdcloser, err := safetemp.Dir("", "getter")
+	td, tdcloser, err := mkdirTemp("", "getter")
 	if err != nil {
 		return err
 	}

--- a/get_http.go
+++ b/get_http.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-cleanhttp"
-	safetemp "github.com/hashicorp/go-safetemp"
 )
 
 // HttpGetter is a Getter implementation that will download from an HTTP
@@ -514,7 +513,7 @@ func (g *HttpGetter) GetFile(dst string, src *url.URL) error {
 func (g *HttpGetter) getSubdir(ctx context.Context, dst, source, subDir string, opts ...ClientOption) error {
 	// Create a temporary directory to store the full source. This has to be
 	// a non-existent directory.
-	td, tdcloser, err := safetemp.Dir("", "getter")
+	td, tdcloser, err := mkdirTemp("", "getter")
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/cheggaaa/pb v1.0.27
 	github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.65
 	github.com/hashicorp/go-cleanhttp v0.5.2
-	github.com/hashicorp/go-safetemp v1.0.0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/klauspost/compress v1.15.11
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,6 @@ github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.65 h1:81+kWbE1yErFBMjME0I5k3
 github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.65/go.mod h1:WtMzv9T++tfWVea+qB2MXoaqxw33S8bpJslzUike2mQ=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
-github.com/hashicorp/go-safetemp v1.0.0 h1:2HR189eFNrjHQyENnQMMpCiBAsRxzbTMIgBhEyExpmo=
-github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=
 github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/klauspost/compress v1.15.11 h1:Lcadnb3RKGin4FYM/orgq0qde+nc15E5Cbqg4B9Sx9c=

--- a/tempdir.go
+++ b/tempdir.go
@@ -1,0 +1,54 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package getter
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// mkdirTemp creates a new temporary directory that isn't yet created. This
+// can be used with calls that expect a non-existent directory.
+//
+// The temporary directory is also evaluated for symlinks upon creation
+// as some operating systems provide symlinks by default when created.
+//
+// The directory is created as a child of a temporary directory created
+// within the directory dir starting with prefix. The temporary directory
+// returned is always named "temp". The parent directory has the specified
+// prefix.
+//
+// The returned io.Closer should be used to clean up the returned directory.
+// This will properly remove the returned directory and any other temporary
+// files created.
+//
+// If an error is returned, the Closer does not need to be called (and will
+// be nil).
+func mkdirTemp(dir, prefix string) (string, io.Closer, error) {
+	// Create the temporary directory
+	td, err := os.MkdirTemp(dir, prefix)
+	if err != nil {
+		return "", nil, err
+	}
+
+	// we evaluate symlinks as some operating systems (eg: MacOS), that
+	// actually has any temporary directory created as a symlink.
+	// As we have only just created the temporary directory, this is a safe
+	// evaluation to make at this time.
+	td, err = filepath.EvalSymlinks(td)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return filepath.Join(td, "temp"), pathCloser(td), nil
+}
+
+// pathCloser implements io.Closer to remove the given path on Close.
+type pathCloser string
+
+// Close deletes this path.
+func (p pathCloser) Close() error {
+	return os.RemoveAll(string(p))
+}

--- a/tempdir_unix_test.go
+++ b/tempdir_unix_test.go
@@ -1,0 +1,52 @@
+//go:build !windows
+// +build !windows
+
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package getter
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func Test_mkdirTemp(t *testing.T) {
+	d, c, err := mkdirTemp("", "test")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if _, err := os.Stat(d); err == nil || !os.IsNotExist(err) {
+		t.Fatalf("directory %q should not exist", d)
+	}
+
+	parent := filepath.Dir(d)
+	fi, err := os.Stat(parent)
+	if err != nil {
+		t.Fatalf("parent directory error: %s", err)
+	}
+	if v := fi.Mode().Perm(); v != 0700 {
+		t.Fatalf("parent directory should be 0700: %s", v)
+	}
+
+	// Create the directory
+	if err := os.MkdirAll(d, 0755); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if _, err := os.Stat(d); err != nil {
+		t.Fatalf("directory %q should exist", d)
+	}
+
+	// Close should remove it
+	if err := c.Close(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if _, err := os.Stat(d); err == nil || !os.IsNotExist(err) {
+		t.Fatalf("directory %q should not exist", d)
+	}
+	if _, err := os.Stat(parent); err == nil || !os.IsNotExist(err) {
+		t.Fatalf("directory %q should not exist", parent)
+	}
+}

--- a/tempdir_windows_test.go
+++ b/tempdir_windows_test.go
@@ -1,0 +1,52 @@
+//go:build windows
+// +build windows
+
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package getter
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func Test_mkdirTemp(t *testing.T) {
+	d, c, err := mkdirTemp("", "test")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if _, err := os.Stat(d); err == nil || !os.IsNotExist(err) {
+		t.Fatalf("directory %q should not exist", d)
+	}
+
+	parent := filepath.Dir(d)
+	fi, err := os.Stat(parent)
+	if err != nil {
+		t.Fatalf("parent directory error: %s", err)
+	}
+	if v := fi.Mode().Perm(); v != 0777 {
+		t.Fatalf("parent directory should be 0777: %s", v)
+	}
+
+	// Create the directory
+	if err := os.MkdirAll(d, 0755); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if _, err := os.Stat(d); err != nil {
+		t.Fatalf("directory %q should exist", d)
+	}
+
+	// Close should remove it
+	if err := c.Close(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if _, err := os.Stat(d); err == nil || !os.IsNotExist(err) {
+		t.Fatalf("directory %q should not exist", d)
+	}
+	if _, err := os.Stat(parent); err == nil || !os.IsNotExist(err) {
+		t.Fatalf("directory %q should not exist", parent)
+	}
+}


### PR DESCRIPTION
There was a [recent change](https://github.com/hashicorp/go-getter/commit/87541b2501c00df5eaedea6acc61a2a4a4efa5b7) that introduced a check to avoid symlinks inside git sub-directories. This is a good change, however there were two problems at play.

First, there was no test for a "successful" get of a sub-directory within the git client. Second, some operating systems, when creating a temporary directory via `os.Mkdirtemp`, return a symlink. This meant that *no* git sub-directory gets would work due to an unintentional symlink.

This change has two commits. The first is a test to showcase the error, the other replaces the superfluous `go-safetemp` by bringing the tiny library internal, and evaluating any symlinks upon temporary directory creation. There is no other HashiCorp tool utilising the `go-safetemp` package, and it simply creates an indirect dependency for minimal utility code.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
