### PR TITLE
[IND-4227][COMPLIANCE] chore: Fix lint issues-build tags

### DIFF
--- a/detect_file_unix_test.go
+++ b/detect_file_unix_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build test || unix
-// +build test unix
 
 package getter
 

--- a/get_file_unix.go
+++ b/get_file_unix.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-// +build !windows
+//go:build !windows
 
 package getter
 

--- a/get_file_windows.go
+++ b/get_file_windows.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build windows
-// +build windows
 
 package getter
 

--- a/helper/url/url_unix.go
+++ b/helper/url/url_unix.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-// +build !windows
+//go:build !windows
 
 package url
 

--- a/symlinks_unix.go
+++ b/symlinks_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0

--- a/symlinks_unix_test.go
+++ b/symlinks_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0

--- a/symlinks_windows.go
+++ b/symlinks_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0

--- a/symlinks_windows_test.go
+++ b/symlinks_windows_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0

--- a/tempdir_unix_test.go
+++ b/tempdir_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0

--- a/tempdir_windows_test.go
+++ b/tempdir_windows_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0


### PR DESCRIPTION
This change is required to fix lint issues that appeared during CI checks in #566.

Replaced all deprecated `// +build` directives with the modern `//go:build` form
introduced in Go 1.17. This modernizes build constraints to align with the Go 1.24
toolchain and removes obsolete syntax flagged by `go vet` linter.

No runtime or functional behavior changes.

⚠️ Note: This change drops compatibility with Go versions earlier than 1.17,
as they do not support the //go:build syntax.


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
