### PR TITLE
fix: close response body in Bitbucket detector to prevent leak

### DIFF
--- a/detect_bitbucket.go
+++ b/detect_bitbucket.go
@@ -43,6 +43,7 @@ func (d *BitBucketDetector) detectHTTP(src string) (string, bool, error) {
 	if err != nil {
 		return "", true, fmt.Errorf("error looking up BitBucket URL: %w", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode == 403 {
 		// A private repo
 		return "", true, fmt.Errorf(


### PR DESCRIPTION
Fixes #618

## Problem

`detectHTTP` in `detect_bitbucket.go` makes an HTTP GET request to the Bitbucket API but never closes `resp.Body`. This leaks the underlying TCP connection until garbage collection.

## Fix

Add `defer resp.Body.Close()` immediately after the error check.

```go
resp, err := http.Get(infoUrl)
if err != nil {
    return "", true, fmt.Errorf("error looking up BitBucket URL: %w", err)
}
defer resp.Body.Close()  // added
```