### PR TITLE
remove both `.git` files and directories

### DIFF
--- a/get_git.go
+++ b/get_git.go
@@ -431,17 +431,18 @@ func checkGitVersion(ctx context.Context, min string) error {
 	return nil
 }
 
-// removeCaseInsensitiveGitDirectory removes all .git directory variations
+// removeCaseInsensitiveGitDirectory removes any .git entry (directory,
+// regular file used as a gitdir pointer, or symlink) in dst so that a
+// previously-planted .git cannot influence the subsequent `git init`.
 func removeCaseInsensitiveGitDirectory(dst string) error {
 	files, err := os.ReadDir(dst)
 	if err != nil {
 		return fmt.Errorf("failed to read the destination directory %s during git update", dst)
 	}
 	for _, f := range files {
-		if strings.EqualFold(f.Name(), ".git") && f.IsDir() {
-			err := os.RemoveAll(filepath.Join(dst, f.Name()))
-			if err != nil {
-				return fmt.Errorf("failed to remove the .git directory in the destination directory %s during git update", dst)
+		if strings.EqualFold(f.Name(), ".git") {
+			if err := os.RemoveAll(filepath.Join(dst, f.Name())); err != nil {
+				return fmt.Errorf("failed to remove .git entry in the destination directory %s during git update", dst)
 			}
 		}
 	}

--- a/get_git_test.go
+++ b/get_git_test.go
@@ -1252,6 +1252,89 @@ func TestGitGetter_BadGitDirName(t *testing.T) {
 	}
 }
 
+func TestRemoveCaseInsensitiveGitDirectory(t *testing.T) {
+	cases := []struct {
+		name  string
+		entry string
+		setup func(t *testing.T, path string)
+	}{
+		{
+			name:  "lowercase git directory",
+			entry: ".git",
+			setup: func(t *testing.T, path string) {
+				if err := os.Mkdir(path, 0755); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name:  "uppercase git directory",
+			entry: ".GIT",
+			setup: func(t *testing.T, path string) {
+				if err := os.Mkdir(path, 0755); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name:  "git regular file",
+			entry: ".git",
+			setup: func(t *testing.T, path string) {
+				if err := os.WriteFile(path, []byte("gitdir: /tmp/elsewhere\n"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name:  "mixed case git regular file",
+			entry: ".Git",
+			setup: func(t *testing.T, path string) {
+				if err := os.WriteFile(path, []byte("gitdir: /tmp/elsewhere\n"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name:  "git symlink",
+			entry: ".git",
+			setup: func(t *testing.T, path string) {
+				if runtime.GOOS == "windows" {
+					t.Skip("skipping symlink test on windows")
+				}
+				if err := os.Symlink(t.TempDir(), path); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dst := t.TempDir()
+			entryPath := filepath.Join(dst, tc.entry)
+			tc.setup(t, entryPath)
+
+			// A regular file that should be left untouched.
+			keep := filepath.Join(dst, "keep.txt")
+			if err := os.WriteFile(keep, []byte("keep me"), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := removeCaseInsensitiveGitDirectory(dst); err != nil {
+				t.Fatalf("removeCaseInsensitiveGitDirectory returned error: %s", err)
+			}
+
+			if _, err := os.Lstat(entryPath); !os.IsNotExist(err) {
+				t.Fatalf("%s entry still exists after removal", tc.entry)
+			}
+
+			if _, err := os.Stat(keep); err != nil {
+				t.Fatalf("unrelated file was removed: %s", err)
+			}
+		})
+	}
+}
+
 func TestGitGetter_BadRef(t *testing.T) {
 	if !testHasGit {
 		t.Log("git not found, skipping")


### PR DESCRIPTION
Fixes an issue where a `.git` file containing malicious git configurations could be remain after cleanup .


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
