### PR TITLE
fix: escape bare '%' in file paths so file:// detection doesn't fail (#607)

### DIFF
--- a/detect_file.go
+++ b/detect_file.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 // FileDetector implements Detector to detect file paths.
@@ -59,12 +60,40 @@ func fmtFileURL(path string) string {
 	if runtime.GOOS == "windows" {
 		// Make sure we're using "/" on Windows. URLs are "/"-based.
 		path = filepath.ToSlash(path)
-		return fmt.Sprintf("file://%s", path)
+		return fmt.Sprintf("file://%s", escapeBarePercent(path))
 	}
 
 	// Make sure that we don't start with "/" since we add that below.
 	if path[0] == '/' {
 		path = path[1:]
 	}
-	return fmt.Sprintf("file:///%s", path)
+	return fmt.Sprintf("file:///%s", escapeBarePercent(path))
+}
+
+// escapeBarePercent escapes any '%' in a filesystem path that is not already
+// the start of a valid percent-encoding (%XX). Such a '%' (e.g. in a path
+// like "{% if foo %}bar") is a literal filesystem character, but once the
+// path is embedded in a file:// URL it would be parsed as an invalid escape
+// and url.Parse would fail with "invalid URL escape". Escaping it to "%25"
+// lets the URL round-trip back to the original path. Valid existing escapes
+// and other URL metacharacters (such as a "?" query suffix that go-getter
+// supports) are left untouched.
+func escapeBarePercent(path string) string {
+	if !strings.Contains(path, "%") {
+		return path
+	}
+	var b strings.Builder
+	b.Grow(len(path))
+	for i := 0; i < len(path); i++ {
+		if path[i] == '%' && !(i+2 < len(path) && isHex(path[i+1]) && isHex(path[i+2])) {
+			b.WriteString("%25")
+			continue
+		}
+		b.WriteByte(path[i])
+	}
+	return b.String()
+}
+
+func isHex(c byte) bool {
+	return ('0' <= c && c <= '9') || ('a' <= c && c <= 'f') || ('A' <= c && c <= 'F')
 }

--- a/detect_file_test.go
+++ b/detect_file_test.go
@@ -5,6 +5,7 @@ package getter
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -114,5 +115,38 @@ func TestFileDetector_noPwd(t *testing.T) {
 		if out != tc.out {
 			t.Fatalf("%d: bad: %#v", i, out)
 		}
+	}
+}
+
+func TestFileDetector_percentInPath(t *testing.T) {
+	// A literal '%' in a filesystem path (e.g. Jinja2/Copier template
+	// directories like "{% if foo %}bar") must not break detection: the
+	// resulting file:// URL has to parse and round-trip back to the
+	// original path instead of failing with "invalid URL escape".
+	// Regression test for #607.
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses unix-style absolute paths")
+	}
+
+	f := new(FileDetector)
+	pwd := "/pwd"
+	in := "{% if foo %}bar{% endif %}"
+
+	out, ok, err := f.Detect(in, pwd)
+	if err != nil {
+		t.Fatalf("Detect error: %s", err)
+	}
+	if !ok {
+		t.Fatal("Detect did not handle the path")
+	}
+
+	u, err := url.Parse(out)
+	if err != nil {
+		t.Fatalf("parsing detected URL %q failed: %s", out, err)
+	}
+
+	want := filepath.Join(pwd, in)
+	if u.Path != want {
+		t.Fatalf("round-tripped path = %q, want %q (detected url = %q)", u.Path, want, out)
 	}
 }


### PR DESCRIPTION
Closes #607.

## Problem

`FileDetector` converts a local filesystem path into a `file://` URL by plain string concatenation (`fmtFileURL`). If the path contains a literal `%` that isn't a valid percent-encoding — e.g. a [Copier](https://copier.readthedocs.io/)/Jinja2 template directory like `{% if foo %}bar{% endif %}` — the resulting URL fails to parse downstream:

```
parse "/tmp/{% if foo %}bar{% endif %}/app": invalid URL escape "% i"
```

even though the path is perfectly valid on disk. (Reported via KCL, which uses go-getter to resolve source paths.)

## Fix

Escape only **bare** `%` characters (a `%` not followed by two hex digits) to `%25` when building the `file://` URL. The URL then parses and round-trips back to the original path via `u.Path`.

Deliberately narrow:
- valid existing escapes (`%XX`) are left as-is;
- other URL metacharacters that go-getter intentionally supports in file paths — notably a `?query` suffix (`./foo?foo=bar`) — are untouched;
- it's a **no-op for any path that already worked** (paths with no bare `%`), so existing behaviour is unchanged.

## Tests

Added `TestFileDetector_percentInPath`: detects `{% if foo %}bar{% endif %}`, parses the resulting URL, and asserts it round-trips back to the original path. It fails before this change (`invalid URL escape "% i"`) and passes after.

```
$ go test -run 'TestDetect$|TestFileDetector|TestFileGetter|TestSourceDirSubdir|TestGetFile' .
ok  	github.com/hashicorp/go-getter
$ go test ./helper/url/      # ok
$ gofmt -l ... ; go vet .    # clean
```

(The repo's GCS/S3 getter tests fail locally only because they need cloud credentials — unrelated to this change.)