### PR TITLE
fix: escape bare '%' in file paths so file:// detection doesn't fail (#607)

### DIFF
--- a/detect_file.go
+++ b/detect_file.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 // FileDetector implements Detector to detect file paths.
@@ -59,12 +60,40 @@ func fmtFileURL(path string) string {
 	if runtime.GOOS == "windows" {
 		// Make sure we're using "/" on Windows. URLs are "/"-based.
 		path = filepath.ToSlash(path)
-		return fmt.Sprintf("file://%s", path)
+		return fmt.Sprintf("file://%s", escapeBarePercent(path))
 	}
 
 	// Make sure that we don't start with "/" since we add that below.
 	if path[0] == '/' {
 		path = path[1:]
 	}
-	return fmt.Sprintf("file:///%s", path)
+	return fmt.Sprintf("file:///%s", escapeBarePercent(path))
+}
+
+// escapeBarePercent escapes any '%' in a filesystem path that is not already
+// the start of a valid percent-encoding (%XX). Such a '%' (e.g. in a path
+// like "{% if foo %}bar") is a literal filesystem character, but once the
+// path is embedded in a file:// URL it would be parsed as an invalid escape
+// and url.Parse would fail with "invalid URL escape". Escaping it to "%25"
+// lets the URL round-trip back to the original path. Valid existing escapes
+// and other URL metacharacters (such as a "?" query suffix that go-getter
+// supports) are left untouched.
+func escapeBarePercent(path string) string {
+	if !strings.Contains(path, "%") {
+		return path
+	}
+	var b strings.Builder
+	b.Grow(len(path))
+	for i := 0; i < len(path); i++ {
+		if path[i] == '%' && !(i+2 < len(path) && isHex(path[i+1]) && isHex(path[i+2])) {
+			b.WriteString("%25")
+			continue
+		}
+		b.WriteByte(path[i])
+	}
+	return b.String()
+}
+
+func isHex(c byte) bool {
+	return ('0' <= c && c <= '9') || ('a' <= c && c <= 'f') || ('A' <= c && c <= 'F')
 }

--- a/detect_file_test.go
+++ b/detect_file_test.go
@@ -5,6 +5,7 @@ package getter
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -114,5 +115,38 @@ func TestFileDetector_noPwd(t *testing.T) {
 		if out != tc.out {
 			t.Fatalf("%d: bad: %#v", i, out)
 		}
+	}
+}
+
+func TestFileDetector_percentInPath(t *testing.T) {
+	// A literal '%' in a filesystem path (e.g. Jinja2/Copier template
+	// directories like "{% if foo %}bar") must not break detection: the
+	// resulting file:// URL has to parse and round-trip back to the
+	// original path instead of failing with "invalid URL escape".
+	// Regression test for #607.
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses unix-style absolute paths")
+	}
+
+	f := new(FileDetector)
+	pwd := "/pwd"
+	in := "{% if foo %}bar{% endif %}"
+
+	out, ok, err := f.Detect(in, pwd)
+	if err != nil {
+		t.Fatalf("Detect error: %s", err)
+	}
+	if !ok {
+		t.Fatal("Detect did not handle the path")
+	}
+
+	u, err := url.Parse(out)
+	if err != nil {
+		t.Fatalf("parsing detected URL %q failed: %s", out, err)
+	}
+
+	want := filepath.Join(pwd, in)
+	if u.Path != want {
+		t.Fatalf("round-tripped path = %q, want %q (detected url = %q)", u.Path, want, out)
 	}
 }


### PR DESCRIPTION
Closes #607. FileDetector builds a file:// URL by string concatenation; a literal '%' in a path (e.g. a Copier/Jinja2 template dir `{% if foo %}bar{% endif %}`) then fails to parse with `invalid URL escape`. This escapes only bare '%' (not followed by two hex digits) to %25 so the URL round-trips back to the original path. Valid %XX escapes and the supported `?query` suffix are untouched; it's a no-op for paths that already worked. Adds TestFileDetector_percentInPath (fails before, passes after); local detect/file/url tests + gofmt + vet clean.