### PR TITLE
fix: ensure clean remove orphan untracked files

### DIFF
--- a/get_git.go
+++ b/get_git.go
@@ -305,6 +305,14 @@ func (g *GitGetter) update(ctx context.Context, dst, sshKeyFile string, u *url.U
 		return err
 	}
 
+	// Clean
+	cmd = exec.CommandContext(ctx, "git", "clean", "-ffdx")
+	cmd.Dir = dst
+	err = getRunCommand(cmd)
+	if err != nil {
+		return err
+	}
+
 	// Checkout ref branch
 	err = g.checkout(ctx, dst, ref)
 	if err != nil {

--- a/get_git_test.go
+++ b/get_git_test.go
@@ -432,6 +432,54 @@ func TestGitGetter_tag(t *testing.T) {
 	}
 }
 
+// TestGitGetter_updateRemovesDeletedFiles is a regression test: when an already
+// populated destination is updated to a ref in which a file has been deleted,
+// that file must not linger in the working tree. update() reinitializes the
+// repo (removing .git) and resets to the fetched ref, which leaves files that
+// were deleted in the new ref behind as untracked unless they are cleaned.
+func TestGitGetter_updateRemovesDeletedFiles(t *testing.T) {
+	if !testHasGit {
+		t.Skip("git not found, skipping")
+	}
+
+	g := new(GitGetter)
+	dst := filepath.Join(t.TempDir(), "target")
+
+	repo := testGitRepo(t, "update-removes-deleted")
+	repo.commitFile("stays.txt", "stays")
+	repo.commitFile("goes.txt", "goes")
+	repo.git("tag", "v1")
+
+	// v2 deletes goes.txt.
+	repo.git("rm", "goes.txt")
+	repo.git("commit", "-m", "remove goes.txt")
+	repo.git("tag", "v2")
+
+	get := func(ref string) {
+		q := repo.url.Query()
+		q.Set("ref", ref)
+		repo.url.RawQuery = q.Encode()
+		if err := g.Get(dst, repo.url); err != nil {
+			t.Fatalf("get ref %s: %s", ref, err)
+		}
+	}
+
+	// First fetch v1: both files present.
+	get("v1")
+	if _, err := os.Stat(filepath.Join(dst, "goes.txt")); err != nil {
+		t.Fatalf("goes.txt should exist after fetching v1: %s", err)
+	}
+
+	// Update the same destination to v2: goes.txt must be gone.
+	get("v2")
+	if _, err := os.Stat(filepath.Join(dst, "stays.txt")); err != nil {
+		t.Fatalf("stays.txt should still exist after update to v2: %s", err)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "goes.txt")); !os.IsNotExist(err) {
+		t.Fatalf("goes.txt was deleted in v2 but still present after update (err=%v)", err)
+	}
+}
+
 func TestGitGetter_checkoutRefOptionInjectionRejected(t *testing.T) {
 	if !testHasGit {
 		t.Skip("git not found, skipping")


### PR DESCRIPTION
As it removes the .git folder and recreates it, update method transforms any deleted git resource into a untracked resource.

fix of #651 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
