### PR TITLE
Fix off-by-one in tar FilesLimit that rejects archives at exactly the limit

### DIFF
--- a/decompress_tar.go
+++ b/decompress_tar.go
@@ -26,13 +26,6 @@ func untar(input io.Reader, dst, src string, dir bool, umask os.FileMode, fileSi
 	)
 
 	for {
-		if filesLimit > 0 {
-			filesCount++
-			if filesCount > filesLimit {
-				return fmt.Errorf("tar archive contains too many files: %d > %d", filesCount, filesLimit)
-			}
-		}
-
 		hdr, err := tarR.Next()
 		if err == io.EOF {
 			if !done {
@@ -44,6 +37,13 @@ func untar(input io.Reader, dst, src string, dir bool, umask os.FileMode, fileSi
 		}
 		if err != nil {
 			return err
+		}
+
+		if filesLimit > 0 {
+			filesCount++
+			if filesCount > filesLimit {
+				return fmt.Errorf("tar archive contains too many files: %d > %d", filesCount, filesLimit)
+			}
 		}
 
 		if hdr.Typeflag == tar.TypeXGlobalHeader || hdr.Typeflag == tar.TypeXHeader {

--- a/decompress_tar_test.go
+++ b/decompress_tar_test.go
@@ -126,6 +126,18 @@ func TestTarLimits(t *testing.T) {
 			t.Fatalf("unexpected error: %q", err.Error())
 		}
 	})
+
+	t.Run("files limit exact", func(t *testing.T) {
+		d := new(TarDecompressor)
+
+		d.FilesLimit = len(files)
+
+		dst := filepath.Join(td, "subdir", "files-limit-exact-result")
+
+		if err := d.Decompress(dst, tarFilePath, true, 0022); err != nil {
+			t.Fatalf("an archive with exactly FilesLimit files should decompress, got: %q", err.Error())
+		}
+	})
 }
 
 // testDecompressPermissions decompresses a directory and checks the permissions of the expanded files


### PR DESCRIPTION
`untar` increments and checks the file counter at the top of its read loop, before calling `tarR.Next()`. The final iteration that reads `io.EOF` is counted too, so the counter ends up one higher than the number of entries actually in the archive.

The effect is that a tar with exactly `FilesLimit` files is rejected:

```
tar archive contains too many files: 4 > 3   // a 3-file archive with FilesLimit=3
```

This disagrees with the field's own doc comment ("FilesLimit limits the number of files that are allowed to be decompressed") and with `ZipDecompressor`, which uses `len(zipR.File) > d.FilesLimit` and so accepts an archive at exactly the limit. `untar` is shared by all tar-family decompressors (tar, tbz2, tgz, txz, tzst).

The fix moves the increment/check to after `tarR.Next()` returns a real entry, so `EOF` is no longer counted. Archives with `FilesLimit`+1 entries are still rejected.

I added a `files limit exact` subtest to `TestTarLimits`; it fails before the change (`4 > 3`) and passes after, and the existing `files limit` case (`3 > 2`) is unchanged.
