### PR TITLE
http: return a typed HTTPStatusError for bad response codes

### DIFF
--- a/get_http.go
+++ b/get_http.go
@@ -20,6 +20,23 @@ import (
 	"github.com/hashicorp/go-cleanhttp"
 )
 
+// A HTTPStatusError is returned when an HTTP server responds to a request
+// with a status code the HttpGetter cannot proceed with. It exposes the
+// status code so callers can recognize the kind of failure (for example a
+// 404 versus a 503) with errors.As instead of parsing the error message.
+type HTTPStatusError struct {
+	// StatusCode is the HTTP status code of the response, as defined in the
+	// net/http package (e.g. http.StatusNotFound).
+	StatusCode int
+}
+
+func (err *HTTPStatusError) Error() string {
+	if err == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("bad response code: %d", err.StatusCode)
+}
+
 // HttpGetter is a Getter implementation that will download from an HTTP
 // endpoint.
 //
@@ -272,7 +289,7 @@ func (g *HttpGetter) Get(dst string, u *url.URL) error {
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("bad response code: %d", resp.StatusCode)
+		return &HTTPStatusError{StatusCode: resp.StatusCode}
 	}
 
 	if disabled := xTerraformGetDisabled(ctx); disabled {
@@ -485,7 +502,7 @@ func (g *HttpGetter) GetFile(dst string, src *url.URL) error {
 		// all good
 	default:
 		_ = resp.Body.Close()
-		return fmt.Errorf("bad response code: %d", resp.StatusCode)
+		return &HTTPStatusError{StatusCode: resp.StatusCode}
 	}
 
 	body := resp.Body

--- a/get_http_test.go
+++ b/get_http_test.go
@@ -206,6 +206,57 @@ func TestHttpGetter_none(t *testing.T) {
 	}
 }
 
+func TestHttpGetter_statusError(t *testing.T) {
+	for _, code := range []int{
+		http.StatusNotFound,
+		http.StatusForbidden,
+		http.StatusServiceUnavailable,
+	} {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+		defer func() { _ = ln.Close() }()
+
+		var server http.Server
+		server.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "nope", code)
+		})
+		go func() { _ = server.Serve(ln) }()
+
+		g := new(HttpGetter)
+
+		var u url.URL
+		u.Scheme = "http"
+		u.Host = ln.Addr().String()
+		u.Path = "/anything"
+
+		// Both the directory (Get) and single-file (GetFile) paths must
+		// surface the status code as a *HTTPStatusError.
+		gets := map[string]func() error{
+			"Get":     func() error { return g.Get(filepath.Join(t.TempDir(), "target"), &u) },
+			"GetFile": func() error { return g.GetFile(filepath.Join(t.TempDir(), "target"), &u) },
+		}
+		for name, get := range gets {
+			err := get()
+			if err == nil {
+				t.Fatalf("%s with status %d: should error", name, code)
+			}
+			var statusErr *HTTPStatusError
+			if !errors.As(err, &statusErr) {
+				t.Fatalf("%s with status %d: expected *HTTPStatusError, got %T: %s", name, code, err, err)
+			}
+			if statusErr.StatusCode != code {
+				t.Fatalf("%s: expected status code %d, got %d", name, code, statusErr.StatusCode)
+			}
+			expected := fmt.Sprintf("bad response code: %d", code)
+			if err.Error() != expected {
+				t.Fatalf("%s: expected error message %q, got %q", name, expected, err.Error())
+			}
+		}
+	}
+}
+
 func TestHttpGetter_resume(t *testing.T) {
 	load := []byte(testHttpMetaStr)
 	sha := sha256.New()


### PR DESCRIPTION
The `HttpGetter` previously reported a non-2xx response as an untyped `fmt.Errorf("bad response code: %d")`, so callers could not distinguish, or example, a 404 from a 503 without parsing the message. Both the directory (`Get`) and single-file (`GetFile`) download paths now return a `*HTTPStatusError` carrying the status code, recoverable with `errors.As`.

I'd like to be able to figure out what error code is returned without parsing the error string. This is not a unique need:

> // The errors returned by this function are those surfaced by the underlying
> // go-getter library, which have very inconsistent quality as
> // end-user-actionable error messages. At this time we do not have any
> // reasonable way to improve these error messages at this layer because
> // the underlying errors are not separately recognizable.

src: https://github.com/hashicorp/terraform/blob/main/internal/getmodules/getter.go#L117-L121

The error message as displayed is unchanged, so callers matching on the string keep working.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [X] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

Not applicable

- [ ] If applicable, I've documented the impact of any changes to security controls.

Not applicable
