### PR TITLE
git: include underlying errors when resolving checkout refs

### DIFF
--- a/get_git.go
+++ b/get_git.go
@@ -191,17 +191,46 @@ func resolveCheckoutRef(ctx context.Context, dst, ref string) (string, error) {
 		"refs/tags/" + ref,
 	}
 
+	var gitErrs []string
 	for _, candidate := range candidates {
 		cmd := exec.CommandContext(ctx, "git", "rev-parse", "--verify", "--quiet", "--end-of-options", candidate+"^{commit}")
 		cmd.Dir = dst
+
+		// Capture stderr so callers see the real git failure (for example
+		// dubious ownership) instead of only a generic invalid-ref message.
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
 
 		resolvedRef, err := cmd.Output()
 		if err == nil {
 			return strings.TrimSpace(string(resolvedRef)), nil
 		}
+
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		if msg != "" {
+			gitErrs = append(gitErrs, msg)
+		}
 	}
 
-	return "", fmt.Errorf("invalid ref: %q", ref)
+	if len(gitErrs) == 0 {
+		return "", fmt.Errorf("invalid ref: %q", ref)
+	}
+
+	// Deduplicate identical messages across candidates.
+	seen := make(map[string]struct{}, len(gitErrs))
+	uniq := make([]string, 0, len(gitErrs))
+	for _, msg := range gitErrs {
+		if _, ok := seen[msg]; ok {
+			continue
+		}
+		seen[msg] = struct{}{}
+		uniq = append(uniq, msg)
+	}
+
+	return "", fmt.Errorf("invalid ref: %q: %s", ref, strings.Join(uniq, "; "))
 }
 
 // gitCommitIDRegex is a pattern intended to match strings that seem

--- a/get_git_test.go
+++ b/get_git_test.go
@@ -552,6 +552,28 @@ func TestGitGetter_checkoutRefShellMetacharactersRejected(t *testing.T) {
 	}
 }
 
+func TestGitGetter_resolveCheckoutRefIncludesGitError(t *testing.T) {
+	if !testHasGit {
+		t.Skip("git not found, skipping")
+	}
+
+	// A non-repository directory makes rev-parse fail with a real git stderr
+	// message that should be surfaced to the caller.
+	dir := t.TempDir()
+	_, err := resolveCheckoutRef(context.Background(), dir, "HEAD")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "invalid ref") {
+		t.Fatalf("expected invalid ref prefix, got: %s", errMsg)
+	}
+	lower := strings.ToLower(errMsg)
+	if !strings.Contains(lower, "not a git repository") && !strings.Contains(lower, "fatal:") {
+		t.Fatalf("expected underlying git error details, got: %s", errMsg)
+	}
+}
+
 func TestGitGetter_GetFile(t *testing.T) {
 	if !testHasGit {
 		t.Skip("git not found, skipping")


### PR DESCRIPTION
## Summary
- When `resolveCheckoutRef` fails every `git rev-parse` candidate, include the captured git stderr in the returned error.
- Deduplicate repeated messages across candidates so the error stays readable.
- Add a regression test that checks a non-repository directory surfaces the underlying git failure instead of only `invalid ref`.

Fixes #649

## Test plan
- [x] `go test -count=1 -run "TestGitGetter_checkoutRef|TestGitGetter_resolveCheckoutRef" .`
- [ ] Confirm a dubious-ownership / non-repo failure now includes the git message after `invalid ref`