### PR TITLE
Add a -version flag to the cli.

### DIFF
--- a/cmd/go-getter/main.go
+++ b/cmd/go-getter/main.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package main
@@ -6,19 +6,26 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"os"
 	"os/signal"
 	"sync"
 
 	getter "github.com/hashicorp/go-getter"
+	ver "github.com/hashicorp/go-getter/version"
 )
 
 func main() {
 	modeRaw := flag.String("mode", "any", "get mode (any, file, dir)")
 	progress := flag.Bool("progress", false, "display terminal progress")
 	insecure := flag.Bool("insecure", false, "do not verify server's certificate chain (not recommended)")
+	version := flag.Bool("version", false, "display version")
 	flag.Parse()
+	if *version {
+		fmt.Println(ver.FullVersionString())
+		os.Exit(0)
+	}
 	args := flag.Args()
 	if len(args) < 2 {
 		log.Fatalf("Expected two args: URL and dst")

--- a/version/version.go
+++ b/version/version.go
@@ -3,9 +3,29 @@
 
 package version
 
+import (
+	"bytes"
+	"fmt"
+)
+
 var (
 	Version           = "1.8.9"
 	VersionPrerelease = "dev"
 	VersionMetadata   = ""
 	// PluginVersion removed to avoid import cycle
 )
+
+func FullVersionString() string {
+	var versionString bytes.Buffer
+
+	fmt.Fprintf(&versionString, "Go-Getter v%s", Version)
+	if VersionPrerelease != "" {
+		fmt.Fprintf(&versionString, "-%s", VersionPrerelease)
+	}
+
+	if VersionMetadata != "" {
+		fmt.Fprintf(&versionString, "+%s", VersionMetadata)
+	}
+
+	return versionString.String()
+}


### PR DESCRIPTION
Reason: adding a version flag to the cli so that it is identifiable.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [X] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
