### PR TITLE
git: surface underlying git error when resolving checkout refs (#649)

### DIFF
--- a/get_git.go
+++ b/get_git.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -191,6 +192,11 @@ func resolveCheckoutRef(ctx context.Context, dst, ref string) (string, error) {
 		"refs/tags/" + ref,
 	}
 
+	// Collect the underlying git error(s) so that a failure caused by the
+	// environment (e.g. a safe.directory ownership check, a permission error,
+	// or a missing repository) is surfaced instead of being masked by a generic
+	// "invalid ref" message. See #649.
+	var gitErrs []string
 	for _, candidate := range candidates {
 		cmd := exec.CommandContext(ctx, "git", "rev-parse", "--verify", "--quiet", "--end-of-options", candidate+"^{commit}")
 		cmd.Dir = dst
@@ -199,8 +205,19 @@ func resolveCheckoutRef(ctx context.Context, dst, ref string) (string, error) {
 		if err == nil {
 			return strings.TrimSpace(string(resolvedRef)), nil
 		}
+		// cmd.Output leaves git's stderr in ExitError.Stderr when cmd.Stderr is
+		// nil; --quiet suppresses "unknown revision" noise, so anything left is
+		// a real underlying cause worth reporting.
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			if msg := strings.TrimSpace(string(exitErr.Stderr)); msg != "" && !slices.Contains(gitErrs, msg) {
+				gitErrs = append(gitErrs, msg)
+			}
+		}
 	}
 
+	if len(gitErrs) > 0 {
+		return "", fmt.Errorf("invalid ref: %q: %s", ref, strings.Join(gitErrs, "; "))
+	}
 	return "", fmt.Errorf("invalid ref: %q", ref)
 }
 

--- a/get_git_resolveref_test.go
+++ b/get_git_resolveref_test.go
@@ -1,0 +1,35 @@
+package getter
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+)
+
+// Reproducer for #649: when resolveCheckoutRef fails for an environmental
+// reason (here: dst is not a git repository), the returned error should surface
+// the underlying git message, not just a generic "invalid ref".
+func TestResolveCheckoutRef_SurfacesGitError(t *testing.T) {
+	if !testHasGit {
+		t.Skip("git not available")
+	}
+	dir, err := os.MkdirTemp("", "gg-notrepo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	_, err = resolveCheckoutRef(context.Background(), dir, "v1.2.3")
+	if err == nil {
+		t.Fatal("expected an error resolving a ref in a non-repository dir")
+	}
+	t.Logf("error: %v", err)
+	// Before the fix the message is exactly `invalid ref: "v1.2.3"` with no
+	// underlying cause. After the fix it also carries git's own message
+	// (e.g. "not a git repository").
+	low := strings.ToLower(err.Error())
+	if !strings.Contains(low, "git") && !strings.Contains(low, "repository") {
+		t.Fatalf("error does not surface the underlying git cause: %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #649.

## Summary

`resolveCheckoutRef` in `get_git.go` runs `git rev-parse` for each ref candidate via `cmd.Output()`. When every candidate fails, it returns a generic:

```
invalid ref: "<ref>"
```

`cmd.Output()` captures git's stderr into `(*exec.ExitError).Stderr`, but that output is discarded. So when the real cause is environmental — a `safe.directory` ownership check, a permission error, or the target not being a git repository — the caller (e.g. a Terraform module download) sees a misleading `invalid ref` that looks like a URL/ref formatting problem, when the ref is actually fine.

## Fix

Collect the underlying git stderr from each failing candidate, deduplicate it (the same environmental error repeats across all three candidates), and include it in the returned error:

```
invalid ref: "v1.2.3": fatal: not a git repository (or any of the parent directories): .git
```

When no candidate produced stderr (a genuinely unknown ref — `--quiet` suppresses the "unknown revision" noise), the original generic message is preserved unchanged, so existing behaviour for the real "invalid ref" case is unaffected.

## Test

Adds `TestResolveCheckoutRef_SurfacesGitError`: resolving a ref inside a non-repository directory must surface git's own message rather than only `invalid ref`.

## Verification (local, go1.23.6 + git 2.47.3)

- **RED→GREEN**: without the change the new test fails (error is exactly `invalid ref: "v1.2.3"`); with the change it passes, surfacing `fatal: not a git repository ...`.
- `go test` for the git getter suite passes with no regressions.
- `gofmt -l` clean, `go vet ./...` clean, `go build ./...` succeeds.

## Contributor checklist

- [x] **LLM Usage** — This change was prepared with AI assistance. Per the AI usage guide, I have reviewed and understand every line, verified it follows the project style, and can explain it during review. The fix and its verification were run against real git; the results above are actual output, not generated.
- [x] Clear reason for and description of the change (above).
- [x] No revert plan needed — the change is additive to an error path and preserves the prior message when no git stderr is available.
- [x] No impact to security controls.