### PR TITLE
fix: percent-escape filesystem paths in file:// URLs

### DIFF
--- a/detect_file.go
+++ b/detect_file.go
@@ -5,9 +5,11 @@ package getter
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 // FileDetector implements Detector to detect file paths.
@@ -59,12 +61,23 @@ func fmtFileURL(path string) string {
 	if runtime.GOOS == "windows" {
 		// Make sure we're using "/" on Windows. URLs are "/"-based.
 		path = filepath.ToSlash(path)
-		return fmt.Sprintf("file://%s", path)
 	}
 
-	// Make sure that we don't start with "/" since we add that below.
-	if path[0] == '/' {
-		path = path[1:]
+	// Query parameters (checksum, archive, etc.) are part of the source
+	// string, not the filesystem path, and must not be percent-encoded.
+	var rawQuery string
+	if idx := strings.Index(path, "?"); idx >= 0 {
+		rawQuery = path[idx+1:]
+		path = path[:idx]
 	}
-	return fmt.Sprintf("file:///%s", path)
+
+	// Build the file URL via net/url so characters such as '%' are escaped.
+	// Concatenating the raw path produces strings that net/url.Parse rejects
+	// (invalid URL escape) even when they are valid filesystem paths.
+	u := url.URL{
+		Scheme:   "file",
+		Path:     path,
+		RawQuery: rawQuery,
+	}
+	return u.String()
 }

--- a/detect_file_test.go
+++ b/detect_file_test.go
@@ -21,6 +21,11 @@ var fileTests = []fileTest{
 	{"./foo", "/pwd", "file:///pwd/foo", false},
 	{"./foo?foo=bar", "/pwd", "file:///pwd/foo?foo=bar", false},
 	{"foo", "/pwd", "file:///pwd/foo", false},
+
+	// https://github.com/hashicorp/go-getter/issues/607
+	{"{% if foo %}bar{% endif %}", "/pwd",
+		"file:///pwd/%7B%25%20if%20foo%20%25%7Dbar%7B%25%20endif%20%25%7D", false},
+	{"100%", "/pwd", "file:///pwd/100%25", false},
 }
 
 var unixFileTests = []fileTest{
@@ -29,12 +34,18 @@ var unixFileTests = []fileTest{
 
 	{"/foo", "/pwd", "file:///foo", false},
 	{"/foo?bar=baz", "/pwd", "file:///foo?bar=baz", false},
+
+	// https://github.com/hashicorp/go-getter/issues/607
+	{"/foo%zz?bar=baz", "/pwd", "file:///foo%25zz?bar=baz", false},
 }
 
 var winFileTests = []fileTest{
 	{"/foo", "/pwd", "file:///pwd/foo", false},
 	{`C:\`, `/pwd`, `file://C:/`, false},
 	{`C:\?bar=baz`, `/pwd`, `file://C:/?bar=baz`, false},
+
+	// https://github.com/hashicorp/go-getter/issues/607
+	{`C:\100%`, `/pwd`, `file://C:/100%25`, false},
 }
 
 func TestFileDetector(t *testing.T) {

--- a/detect_test.go
+++ b/detect_test.go
@@ -60,6 +60,20 @@ func TestDetect(t *testing.T) {
 			false,
 		},
 
+		// https://github.com/hashicorp/go-getter/issues/607
+		{
+			"{% if foo %}bar{% endif %}",
+			"/pwd",
+			"file:///pwd/%7B%25%20if%20foo%20%25%7Dbar%7B%25%20endif%20%25%7D",
+			false,
+		},
+		{
+			"100%",
+			"/pwd",
+			"file:///pwd/100%25",
+			false,
+		},
+
 		// https://github.com/hashicorp/go-getter/pull/124
 		{
 			"git::ssh://git@my.custom.git/dir1/dir2",

--- a/get_test.go
+++ b/get_test.go
@@ -93,6 +93,45 @@ func TestGet_fileDetect(t *testing.T) {
 	}
 }
 
+// https://github.com/hashicorp/go-getter/issues/607
+func TestGet_fileDetectPercentInPath(t *testing.T) {
+	cases := []struct {
+		name    string
+		srcName string
+	}{
+		{"jinja", "{% if foo %}bar{% endif %}"},
+		{"trailing", "100%"},
+		{"invalid-hex", "foo%zz"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			srcDir := filepath.Join(tmp, tc.srcName)
+			if err := os.MkdirAll(srcDir, 0755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(srcDir, "test.txt"), []byte("hello"), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			dst := filepath.Join(tmp, "output")
+			client := &Client{
+				Src:  tc.srcName,
+				Dst:  dst,
+				Pwd:  tmp,
+				Mode: ClientModeDir,
+			}
+			if err := client.Get(); err != nil {
+				t.Fatalf("Get: %s", err)
+			}
+			if _, err := os.Stat(filepath.Join(dst, "test.txt")); err != nil {
+				t.Fatalf("stat: %s", err)
+			}
+		})
+	}
+}
+
 func TestGet_fileForced(t *testing.T) {
 	dst := filepath.Join(t.TempDir(), "target")
 	u := testModule("basic")


### PR DESCRIPTION
## Summary
`fmtFileURL` concatenated filesystem paths into `file://` URLs without escaping, so a literal `%` in a path (Jinja `{% if %}`, `100%`, `foo%zz`) made `net/url.Parse` fail with `invalid URL escape` even though the path is valid on disk.

Build the URL with `net/url` so special characters are escaped. Query parameters (`?checksum=`, `?archive=`) stay on `RawQuery` and are not path-encoded. Existing `basic%2Ftest` / RawPath behavior is unchanged.

Fixes #607

## Test plan
- [x] `go test -count=1 -run 'TestGet_fileDetectPercentInPath|TestGet_filePercent2F|TestFileDetector|TestDetect$|TestFileGetter_percent2F' .`
- [x] New `TestGet_fileDetectPercentInPath` failed RED before the change and passes after